### PR TITLE
Migrate :text bindings to {{ }} interpolation (stx 0.2.72)

### DIFF
--- a/resources/components/Bench/Admin/AdminDashboard.stx
+++ b/resources/components/Bench/Admin/AdminDashboard.stx
@@ -38,12 +38,12 @@
   <div class="gap-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
     <StxLink to="/admin/reviews" class="block p-6 bg-white border border-gray-200 rounded-lg hover:shadow-sm transition-shadow">
       <p class="font-medium text-gray-500 text-sm">Pending reviews</p>
-      <p class="mt-2 font-bold text-3xl text-gray-900" :text="pendingCount()"></p>
+      <p class="mt-2 font-bold text-3xl text-gray-900">{{ pendingCount() }}</p>
       <p class="mt-2 font-semibold text-gray-600 text-sm">Open moderation queue &rarr;</p>
     </StxLink>
     <StxLink to="/admin/users" class="block p-6 bg-white border border-gray-200 rounded-lg hover:shadow-sm transition-shadow">
       <p class="font-medium text-gray-500 text-sm">Total users</p>
-      <p class="mt-2 font-bold text-3xl text-gray-900" :text="userCount()"></p>
+      <p class="mt-2 font-bold text-3xl text-gray-900">{{ userCount() }}</p>
       <p class="mt-2 font-semibold text-gray-600 text-sm">Manage users &rarr;</p>
     </StxLink>
     <div class="block p-6 bg-white border border-gray-200 rounded-lg">

--- a/resources/components/Bench/Admin/AdminShell.stx
+++ b/resources/components/Bench/Admin/AdminShell.stx
@@ -107,7 +107,7 @@
         </nav>
       </div>
       <div class="flex gap-x-4 items-center">
-        <span class="hidden sm:inline text-gray-600 text-sm" :text="adminName"></span>
+        <span class="hidden sm:inline text-gray-600 text-sm">{{ adminName }}</span>
         <StxLink to="/" class="text-gray-500 text-sm hover:text-gray-900">View site</StxLink>
         <button
           type="button"

--- a/resources/components/Bench/Admin/CredentialsTable.stx
+++ b/resources/components/Bench/Admin/CredentialsTable.stx
@@ -75,9 +75,7 @@
   <div
     role="alert"
     class="px-4 py-3 text-red-800 text-sm bg-red-50 border border-red-200 rounded-md"
-    x-class="store.actionError() ? '' : 'hidden'"
-    :text="store.actionError()"
-  ></div>
+    x-class="store.actionError() ? '' : 'hidden'">{{ store.actionError() }}</div>
 
   <div class="bg-white border border-gray-200 rounded-lg overflow-hidden">
     <div :if="store.loading() && store.claims().length === 0" class="px-4 py-12 text-center text-gray-500 text-sm">
@@ -100,23 +98,21 @@
             <div class="flex flex-wrap gap-2 items-center">
               <span
                 class="inline-block px-2 py-0.5 font-medium text-xs rounded-full"
-                x-class="isJudgeClaim(claim) ? 'bg-amber-100 text-amber-800' : 'bg-gray-100 text-gray-700'"
-                :text="isJudgeClaim(claim) ? 'Judge claim' : 'Credential'"
-              ></span>
-              <span class="text-gray-500 text-xs" :text="formatDate(claim.credential_claimed_at)"></span>
+                x-class="isJudgeClaim(claim) ? 'bg-amber-100 text-amber-800' : 'bg-gray-100 text-gray-700'">{{ isJudgeClaim(claim) ? 'Judge claim' : 'Credential' }}</span>
+              <span class="text-gray-500 text-xs">{{ formatDate(claim.credential_claimed_at) }}</span>
             </div>
-            <h3 class="mt-1 font-semibold text-gray-900 text-base" :text="claimLabel(claim)"></h3>
+            <h3 class="mt-1 font-semibold text-gray-900 text-base">{{ claimLabel(claim) }}</h3>
             <p class="mt-0.5 text-gray-600 text-sm">
-              <span :text="claim.name"></span>
+              <span>{{ claim.name }}</span>
               <span class="text-gray-400"> · </span>
-              <span :text="claim.email"></span>
+              <span>{{ claim.email }}</span>
             </p>
             <!-- Prior rejection note, if this claim was rejected and resubmitted. -->
             <p
               class="mt-2 px-2 py-1 text-amber-800 text-xs bg-amber-50 border border-amber-200 rounded"
               x-class="hasNote(claim) ? '' : 'hidden'"
             >
-              Previously rejected: <span :text="claim.credential_rejection_note"></span>
+              Previously rejected: <span>{{ claim.credential_rejection_note }}</span>
             </p>
           </div>
           <div class="flex flex-shrink-0 gap-x-2 items-start">

--- a/resources/components/Bench/Admin/ModerationLog.stx
+++ b/resources/components/Bench/Admin/ModerationLog.stx
@@ -56,9 +56,7 @@
   <div
     role="alert"
     class="px-4 py-3 text-red-800 text-sm bg-red-50 border border-red-200 rounded-md"
-    x-class="store.error() ? '' : 'hidden'"
-    :text="store.error()"
-  ></div>
+    x-class="store.error() ? '' : 'hidden'">{{ store.error() }}</div>
 
   <div class="bg-white border border-gray-200 rounded-lg overflow-hidden">
     <div :if="store.loading() && store.logs().length === 0" class="px-4 py-12 text-center text-gray-500 text-sm">
@@ -76,14 +74,14 @@
     <ul x-class="hasLogs() ? 'divide-gray-100 divide-y' : 'hidden'">
       <li :for="entry in store.logs" class="px-4 py-3">
         <div class="flex flex-wrap gap-2 items-center">
-          <span class="inline-block px-2 py-0.5 font-medium text-xs rounded-full" x-class="actionTone(entry)" :text="actionLabel(entry)"></span>
-          <span class="font-medium text-gray-900 text-sm" :text="targetLabel(entry)"></span>
+          <span class="inline-block px-2 py-0.5 font-medium text-xs rounded-full" x-class="actionTone(entry)">{{ actionLabel(entry) }}</span>
+          <span class="font-medium text-gray-900 text-sm">{{ targetLabel(entry) }}</span>
           <span class="text-gray-400 text-xs">·</span>
-          <span class="text-gray-600 text-xs">by <span :text="entry.actor_name"></span></span>
+          <span class="text-gray-600 text-xs">by <span>{{ entry.actor_name }}</span></span>
           <span class="text-gray-400 text-xs">·</span>
-          <span class="text-gray-500 text-xs" :text="formatDate(entry.created_at)"></span>
+          <span class="text-gray-500 text-xs">{{ formatDate(entry.created_at) }}</span>
         </div>
-        <p class="mt-1 text-gray-600 text-xs" x-class="hasNote(entry) ? '' : 'hidden'" :text="entry.note"></p>
+        <p class="mt-1 text-gray-600 text-xs" x-class="hasNote(entry) ? '' : 'hidden'">{{ entry.note }}</p>
       </li>
     </ul>
   </div>

--- a/resources/components/Bench/Admin/ReviewsTable.stx
+++ b/resources/components/Bench/Admin/ReviewsTable.stx
@@ -156,7 +156,7 @@
     <div>
       <h1 class="font-bold text-2xl text-gray-900">Reviews</h1>
       <p class="mt-1 text-gray-600 text-sm">
-        <span :text="store.total()"></span> <span :text="store.statusFilter()"></span>
+        <span>{{ store.total() }}</span> <span>{{ store.statusFilter() }}</span>
       </p>
     </div>
     <div>
@@ -177,17 +177,13 @@
       type="button"
       @click="setFilter(tab.key)"
       class="px-4 py-2 font-medium text-sm border-b-2 transition-colors"
-      x-class="store.statusFilter() === tab.key ? 'border-gray-900 text-gray-900' : 'border-transparent text-gray-500 hover:text-gray-900 hover:border-gray-300'"
-      :text="tab.label"
-    ></button>
+      x-class="store.statusFilter() === tab.key ? 'border-gray-900 text-gray-900' : 'border-transparent text-gray-500 hover:text-gray-900 hover:border-gray-300'">{{ tab.label }}</button>
   </div>
 
   <div
     role="alert"
     class="px-4 py-3 text-red-800 text-sm bg-red-50 border border-red-200 rounded-md"
-    x-class="store.actionError() ? '' : 'hidden'"
-    :text="store.actionError()"
-  ></div>
+    x-class="store.actionError() ? '' : 'hidden'">{{ store.actionError() }}</div>
 
   <div class="bg-white border border-gray-200 rounded-lg overflow-hidden">
     <div :if="store.loading() && store.reviews().length === 0" class="px-4 py-12 text-center text-gray-500 text-sm">
@@ -206,8 +202,8 @@
           <path d="M9 12h6m-6 4h6M7 4h10a2 2 0 012 2v12a2 2 0 01-2 2H7a2 2 0 01-2-2V6a2 2 0 012-2z" />
         </svg>
       </div>
-      <p class="font-semibold text-gray-900 text-sm" :text="emptyTitle()"></p>
-      <p class="mt-1 max-w-md mx-auto text-gray-500 text-xs leading-relaxed" :text="emptyHint()"></p>
+      <p class="font-semibold text-gray-900 text-sm">{{ emptyTitle() }}</p>
+      <p class="mt-1 max-w-md mx-auto text-gray-500 text-xs leading-relaxed">{{ emptyHint() }}</p>
     </div>
     <!-- x-class hidden (not :if) so the inner :for keeps its
          subscription across the loading -> loaded transition. The
@@ -220,19 +216,17 @@
             <div class="flex gap-x-2 items-center">
               <span
                 class="inline-block px-2 py-0.5 font-medium text-xs rounded-full"
-                x-class="review.status === 'published' ? 'bg-emerald-100 text-emerald-800' : review.status === 'rejected' ? 'bg-red-100 text-red-800' : 'bg-amber-100 text-amber-800'"
-                :text="review.status"
-              ></span>
-              <span class="text-gray-500 text-xs" :text="formatDate(review.created_at)"></span>
+                x-class="review.status === 'published' ? 'bg-emerald-100 text-emerald-800' : review.status === 'rejected' ? 'bg-red-100 text-red-800' : 'bg-amber-100 text-amber-800'">{{ review.status }}</span>
+              <span class="text-gray-500 text-xs">{{ formatDate(review.created_at) }}</span>
             </div>
-            <h3 class="mt-1 font-semibold text-gray-900 text-base" :text="review.title"></h3>
+            <h3 class="mt-1 font-semibold text-gray-900 text-base">{{ review.title }}</h3>
             <p class="mt-1 text-gray-600 text-sm">
-              <span :text="review.judge.name"></span>
+              <span>{{ review.judge.name }}</span>
               <span class="text-gray-400"> · </span>
-              <span :if="review.user" :text="review.user ? review.user.email : ''"></span>
+              <span :if="review.user">{{ review.user ? review.user.email : '' }}</span>
               <span :if="!review.user" class="text-gray-400">(anonymous)</span>
               <span class="text-gray-400"> · </span>
-              <span :text="'★ ' + review.rating"></span>
+              <span>{{ '★ ' + review.rating }}</span>
             </p>
           </div>
           <div class="flex flex-shrink-0 flex-col gap-y-1 items-end">
@@ -258,9 +252,7 @@
             <button
               type="button"
               @click="toggleExpand(review)"
-              class="text-gray-500 text-xs hover:text-gray-900"
-              :text="expandedId() === review.id ? 'Hide content' : 'Show content'"
-            ></button>
+              class="text-gray-500 text-xs hover:text-gray-900">{{ expandedId() === review.id ? 'Hide content' : 'Show content' }}</button>
           </div>
         </div>
         <div class="mt-3 space-y-3" x-class="expandedId() === review.id ? '' : 'hidden'">
@@ -285,7 +277,7 @@
                 class="inline-flex items-center justify-center px-3 py-1.5 font-semibold text-white text-xs bg-gray-900 hover:bg-gray-800 rounded disabled:opacity-50"
               >
                 <svg :if="savingResponse()" class="animate-spin -ml-0.5 mr-2 h-4 w-4" viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3" class="opacity-25"></circle><path d="M4 12a8 8 0 018-8" stroke="currentColor" stroke-width="3" stroke-linecap="round"></path></svg>
-                <span :text="savingResponse() ? 'Saving…' : 'Save response'"></span>
+                <span>{{ savingResponse() ? 'Saving…' : 'Save response' }}</span>
               </button>
               <button
                 type="button"
@@ -302,7 +294,7 @@
 
   <div class="flex justify-between items-center">
     <p class="text-gray-500 text-sm">
-      Page <span :text="store.page()"></span> of <span :text="store.totalPages()"></span>
+      Page <span>{{ store.page() }}</span> of <span>{{ store.totalPages() }}</span>
     </p>
     <div class="flex gap-x-2">
       <button

--- a/resources/components/Bench/Admin/UsersTable.stx
+++ b/resources/components/Bench/Admin/UsersTable.stx
@@ -127,7 +127,7 @@
     <div>
       <h1 class="font-bold text-2xl text-gray-900">Users</h1>
       <p class="mt-1 text-gray-600 text-sm">
-        <span :text="store.total()"></span> total
+        <span>{{ store.total() }}</span> total
       </p>
     </div>
     <div>
@@ -145,9 +145,7 @@
   <div
     role="alert"
     class="px-4 py-3 text-red-800 text-sm bg-red-50 border border-red-200 rounded-md"
-    x-class="store.actionError() ? '' : 'hidden'"
-    :text="store.actionError()"
-  ></div>
+    x-class="store.actionError() ? '' : 'hidden'">{{ store.actionError() }}</div>
 
   <div class="bg-white border border-gray-200 rounded-lg overflow-hidden">
     <table class="w-full divide-gray-200 divide-y">
@@ -175,20 +173,20 @@
                 <path d="M17 20h5v-2a4 4 0 00-3-3.87M9 20H4v-2a4 4 0 013-3.87m6 5.87a4 4 0 100-8 4 4 0 000 8zm0 0a4 4 0 014 4M5 8a3 3 0 116 0 3 3 0 01-6 0zm10 0a3 3 0 116 0 3 3 0 01-6 0z" />
               </svg>
             </div>
-            <p class="font-semibold text-gray-900 text-sm" :text="emptyTitle()"></p>
-            <p class="mt-1 max-w-md mx-auto text-gray-500 text-xs leading-relaxed" :text="emptyHint()"></p>
+            <p class="font-semibold text-gray-900 text-sm">{{ emptyTitle() }}</p>
+            <p class="mt-1 max-w-md mx-auto text-gray-500 text-xs leading-relaxed">{{ emptyHint() }}</p>
           </td>
         </tr>
         <tr :for="user in store.users" class="hover:bg-gray-50">
           <td class="px-4 py-3 text-gray-900 text-sm">
             <div class="flex flex-col">
-              <span class="font-medium" :text="user.name || '(no name)'"></span>
-              <span class="text-gray-500 text-xs">id <span :text="user.id"></span></span>
+              <span class="font-medium">{{ user.name || '(no name)' }}</span>
+              <span class="text-gray-500 text-xs">id <span>{{ user.id }}</span></span>
             </div>
           </td>
-          <td class="px-4 py-3 text-gray-700 text-sm" :text="user.email"></td>
-          <td class="px-4 py-3 text-gray-700 text-sm" :text="rolesText(user)"></td>
-          <td class="px-4 py-3 text-gray-500 text-sm" :text="formatDate(user.created_at)"></td>
+          <td class="px-4 py-3 text-gray-700 text-sm">{{ user.email }}</td>
+          <td class="px-4 py-3 text-gray-700 text-sm">{{ rolesText(user) }}</td>
+          <td class="px-4 py-3 text-gray-500 text-sm">{{ formatDate(user.created_at) }}</td>
           <td class="px-4 py-3 text-right text-sm">
             <div class="flex justify-end gap-x-2">
               <button
@@ -201,9 +199,7 @@
                 @click="togglePromote(user)"
                 x-disabled="isSelf(user) && userHasAdmin(user)"
                 class="font-medium text-sm hover:underline disabled:cursor-not-allowed disabled:opacity-40"
-                x-class="userHasAdmin(user) ? 'text-amber-700' : 'text-emerald-700'"
-                :text="userHasAdmin(user) ? 'Demote' : 'Promote'"
-              ></button>
+                x-class="userHasAdmin(user) ? 'text-amber-700' : 'text-emerald-700'">{{ userHasAdmin(user) ? 'Demote' : 'Promote' }}</button>
               <button
                 type="button"
                 @click="confirmDelete(user)"
@@ -219,7 +215,7 @@
 
   <div class="flex justify-between items-center">
     <p class="text-gray-500 text-sm">
-      Page <span :text="store.page()"></span> of <span :text="store.totalPages()"></span>
+      Page <span>{{ store.page() }}</span> of <span>{{ store.totalPages() }}</span>
     </p>
     <div class="flex gap-x-2">
       <button
@@ -258,12 +254,10 @@
         <div
           role="alert"
           class="px-3 py-2 text-red-800 text-sm bg-red-50 border border-red-200 rounded-md"
-          x-class="editError() ? '' : 'hidden'"
-          :text="editError()"
-        ></div>
+          x-class="editError() ? '' : 'hidden'">{{ editError() }}</div>
         <div class="flex justify-end gap-x-2">
           <button type="button" @click="cancelEdit()" x-disabled="saving" class="px-3 py-1.5 font-medium text-gray-700 text-sm bg-white border border-gray-300 rounded hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed">Cancel</button>
-          <button type="button" @click="saveEdit()" x-disabled="saving" class="inline-flex items-center justify-center px-3 py-1.5 font-medium text-white text-sm bg-gray-900 hover:bg-gray-800 rounded disabled:opacity-50 disabled:cursor-not-allowed"><svg :if="saving()" class="animate-spin -ml-0.5 mr-2 h-4 w-4" viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3" class="opacity-25"></circle><path d="M4 12a8 8 0 018-8" stroke="currentColor" stroke-width="3" stroke-linecap="round"></path></svg><span :text="saving() ? 'Saving…' : 'Save'"></span></button>
+          <button type="button" @click="saveEdit()" x-disabled="saving" class="inline-flex items-center justify-center px-3 py-1.5 font-medium text-white text-sm bg-gray-900 hover:bg-gray-800 rounded disabled:opacity-50 disabled:cursor-not-allowed"><svg :if="saving()" class="animate-spin -ml-0.5 mr-2 h-4 w-4" viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3" class="opacity-25"></circle><path d="M4 12a8 8 0 018-8" stroke="currentColor" stroke-width="3" stroke-linecap="round"></path></svg><span>{{ saving() ? 'Saving…' : 'Save' }}</span></button>
         </div>
       </div>
     </div>

--- a/resources/components/Bench/Article.stx
+++ b/resources/components/Bench/Article.stx
@@ -7,7 +7,7 @@
       <div class="flex items-center">
         <Icon :for="star in reviewStars" name="star" size="20" x-class="star <= review.rating ? 'text-yellow-400' : 'text-gray-300'" />
       </div>
-      <span class="ml-2 text-gray-500 text-sm" :text="`(${review.rating})`"></span>
+      <span class="ml-2 text-gray-500 text-sm">{{ `(${review.rating})` }}</span>
     </div>
 
     <div class="relative review-content">
@@ -23,11 +23,11 @@
         <div class="flex items-center space-x-4">
           <button class="inline-flex items-center space-x-2 text-gray-600 hover:text-gray-900">
             <Icon name="heart" size="20" />
-            <span :text="review.likes"></span>
+            <span>{{ review.likes }}</span>
           </button>
           <button class="inline-flex items-center space-x-2 text-gray-600 hover:text-gray-900">
             <Icon name="message-square" size="20" />
-            <span :text="review.comments"></span>
+            <span>{{ review.comments }}</span>
           </button>
         </div>
       </div>

--- a/resources/components/Bench/Article/Comments.stx
+++ b/resources/components/Bench/Article/Comments.stx
@@ -56,7 +56,7 @@
 <div class="mx-auto px-4 sm:px-6 lg:px-8 max-w-5xl">
   <div class="pt-8 border-gray-200 border-t">
     <h2 class="font-semibold text-gray-900 text-xl">
-      Comments <span class="ml-2 text-base text-gray-500" x-text="`(${comments().length})`"></span>
+      Comments <span class="ml-2 text-base text-gray-500">{{ `(${comments().length})` }}</span>
     </h2>
 
     <!-- Comment form -->
@@ -92,10 +92,10 @@
         <img class="flex-none h-10 w-10 rounded-full" x-src="comment.author.imageUrl" x-alt="comment.author.name">
         <div class="flex-auto">
           <div class="flex items-center justify-between">
-            <p class="font-semibold text-gray-900 text-sm" x-text="comment.author.name"></p>
-            <p class="text-gray-500 text-xs" x-text="comment.time"></p>
+            <p class="font-semibold text-gray-900 text-sm">{{ comment.author.name }}</p>
+            <p class="text-gray-500 text-xs">{{ comment.time }}</p>
           </div>
-          <p class="mt-1 leading-6 text-gray-700 text-sm" x-text="comment.content"></p>
+          <p class="mt-1 leading-6 text-gray-700 text-sm">{{ comment.content }}</p>
           <div class="flex gap-x-4 items-center mt-3 text-gray-500 text-xs">
             <button
               type="button"
@@ -103,7 +103,7 @@
               @click="likeComment(comment.id)"
             >
               <Icon name="bookmark" size="16" class="mr-1" />
-              <span x-text="comment.likes"></span>
+              <span>{{ comment.likes }}</span>
             </button>
             <button type="button" class="hover:text-gray-700">Reply</button>
             <button type="button" class="hover:text-gray-700">Report</button>

--- a/resources/components/Bench/ArticleEdit.stx
+++ b/resources/components/Bench/ArticleEdit.stx
@@ -258,9 +258,7 @@
         <div
           role="alert"
           class="px-3 py-2 text-red-800 text-sm bg-red-50 border border-red-200 rounded-md"
-          x-class="editError() ? '' : 'hidden'"
-          :text="editError()"
-        ></div>
+          x-class="editError() ? '' : 'hidden'">{{ editError() }}</div>
 
         <div class="flex justify-end gap-x-2 pt-2">
           <button
@@ -276,7 +274,7 @@
             class="inline-flex items-center justify-center px-4 py-2 font-semibold text-white text-sm bg-gray-900 hover:bg-gray-800 rounded-md disabled:opacity-50"
           >
             <svg :if="editSaving()" class="animate-spin -ml-0.5 mr-2 h-4 w-4" viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3" class="opacity-25"></circle><path d="M4 12a8 8 0 018-8" stroke="currentColor" stroke-width="3" stroke-linecap="round"></path></svg>
-            <span :text="editSaving() ? 'Saving…' : 'Save & resubmit'"></span>
+            <span>{{ editSaving() ? 'Saving…' : 'Save & resubmit' }}</span>
           </button>
         </div>
       </div>

--- a/resources/components/Bench/ArticleHeader.stx
+++ b/resources/components/Bench/ArticleHeader.stx
@@ -1,7 +1,7 @@
 <header class="relative">
   <div class="mx-auto pb-8 pt-16 px-4 sm:px-6 lg:px-8 max-w-5xl">
     <div class="text-center">
-      <h1 class="font-bold text-4xl text-gray-900 tracking-tight sm:text-5xl" :text="review.title"></h1>
+      <h1 class="font-bold text-4xl text-gray-900 tracking-tight sm:text-5xl">{{ review.title }}</h1>
     </div>
 
     <!-- Author and Judge info -->
@@ -10,23 +10,23 @@
         <img class="h-12 w-12 rounded-full" x-src="review.author.imageUrl" x-alt="review.author.name">
         <div class="ml-3">
           <p class="font-medium text-gray-900 text-sm">
-            <a href="#" class="hover:underline" :text="review.author.name"></a>
+            <a href="#" class="hover:underline">{{ review.author.name }}</a>
           </p>
           <div class="flex space-x-1 text-gray-500 text-sm">
-            <time :datetime="review.dateTime" :text="review.date"></time>
+            <time :datetime="review.dateTime">{{ review.date }}</time>
             <span aria-hidden="true">&middot;</span>
           </div>
         </div>
       </div>
       <div class="text-right">
         <div class="flex flex-col items-end">
-          <span class="inline-flex items-center mb-2 px-2 py-1 font-medium text-green-700 text-xs bg-green-50 ring-1 ring-green-600/20 ring-inset rounded-full" :text="review.type"></span>
+          <span class="inline-flex items-center mb-2 px-2 py-1 font-medium text-green-700 text-xs bg-green-50 ring-1 ring-green-600/20 ring-inset rounded-full">{{ review.type }}</span>
           <h2 class="font-semibold text-gray-900 text-lg">Reviewing</h2>
           <div class="flex items-center justify-end mt-1">
             <img class="h-10 w-10 rounded-full" x-src="review.judge.photo" x-alt="review.judge.name">
             <div class="ml-3">
-              <p class="font-medium text-gray-900 text-sm" :text="review.judge.name"></p>
-              <p class="text-gray-500 text-sm" :text="review.judge.court"></p>
+              <p class="font-medium text-gray-900 text-sm">{{ review.judge.name }}</p>
+              <p class="text-gray-500 text-sm">{{ review.judge.court }}</p>
             </div>
           </div>
         </div>

--- a/resources/components/Bench/ArticleView.stx
+++ b/resources/components/Bench/ArticleView.stx
@@ -479,8 +479,8 @@
     >
       <div class="flex flex-wrap items-start justify-between gap-3">
         <div class="flex-1 min-w-0">
-          <p class="font-semibold text-sm" :text="statusLabel"></p>
-          <p class="mt-1 text-xs leading-relaxed" :text="statusBlurb"></p>
+          <p class="font-semibold text-sm">{{ statusLabel }}</p>
+          <p class="mt-1 text-xs leading-relaxed">{{ statusBlurb }}</p>
         </div>
         <div class="flex flex-shrink-0 gap-x-2">
           <button
@@ -495,7 +495,7 @@
             class="inline-flex items-center justify-center px-3 py-1.5 font-semibold text-red-700 text-xs bg-white border border-red-200 rounded-md hover:bg-red-50 disabled:opacity-50"
           >
             <svg :if="deleting()" class="animate-spin -ml-0.5 mr-2 h-4 w-4" viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3" class="opacity-25"></circle><path d="M4 12a8 8 0 018-8" stroke="currentColor" stroke-width="3" stroke-linecap="round"></path></svg>
-            <span :text="deleting() ? 'Deleting…' : 'Delete'"></span>
+            <span>{{ deleting() ? 'Deleting…' : 'Delete' }}</span>
           </button>
         </div>
       </div>
@@ -507,15 +507,13 @@
     <div
       role="alert"
       class="mb-6 px-3 py-2 text-red-800 text-sm bg-red-50 border border-red-200 rounded-md"
-      x-class="editError() ? '' : 'hidden'"
-      :text="editError()"
-    ></div>
+      x-class="editError() ? '' : 'hidden'">{{ editError() }}</div>
 
     <!-- Topic chip -->
-    <p class="font-medium text-amber-600 text-center text-xs tracking-widest uppercase" :text="reviewTypeLabel"></p>
+    <p class="font-medium text-amber-600 text-center text-xs tracking-widest uppercase">{{ reviewTypeLabel }}</p>
 
     <!-- Hero title — large serif, tight tracking, generous bottom margin -->
-    <h1 class="mt-4 font-serif font-bold leading-[1.1] text-4xl sm:text-5xl lg:text-6xl text-center text-gray-900 tracking-tight" :text="title"></h1>
+    <h1 class="mt-4 font-serif font-bold leading-[1.1] text-4xl sm:text-5xl lg:text-6xl text-center text-gray-900 tracking-tight">{{ title }}</h1>
 
     <!-- Star rating + date + read time row. Centered, subtle. -->
     <div class="flex flex-wrap items-center justify-center gap-x-4 gap-y-2 mt-8 text-gray-500 text-sm">
@@ -529,12 +527,12 @@
             <path d="M11.525 2.295a.53.53 0 0 1 .95 0l2.31 4.679a2.12 2.12 0 0 0 1.595 1.16l5.166.756a.53.53 0 0 1 .294.904l-3.736 3.638a2.12 2.12 0 0 0-.611 1.878l.882 5.14a.53.53 0 0 1-.771.56l-4.618-2.428a2.12 2.12 0 0 0-1.973 0L6.396 21.01a.53.53 0 0 1-.77-.56l.881-5.139a2.12 2.12 0 0 0-.611-1.879L2.16 9.795a.53.53 0 0 1 .294-.906l5.165-.755a2.12 2.12 0 0 0 1.597-1.16z" />
           </svg>
         </span>
-        <span class="ml-2 font-medium text-gray-700 tabular-nums" :text="`${rating}/5`"></span>
+        <span class="ml-2 font-medium text-gray-700 tabular-nums">{{ `${rating}/5` }}</span>
       </div>
       <span class="hidden sm:inline text-gray-300">·</span>
-      <span :text="date"></span>
+      <span>{{ date }}</span>
       <span class="hidden sm:inline text-gray-300">·</span>
-      <span :text="`${readMinutes} min read`"></span>
+      <span>{{ `${readMinutes} min read` }}</span>
       <!-- Reviewer line. Three rendering modes (bench-review#29, #36):
            - Linked: real user → "by <Name>" with click-through to /user/:id
            - Plain:  anonymized → "by Anonymous attorney" with no link
@@ -542,9 +540,9 @@
       <span :if="hasReviewerName" class="hidden sm:inline text-gray-300">·</span>
       <span :if="hasReviewerLink" class="text-gray-500">
         by
-        <StxLink x-to="`/user/${reviewerId}`" class="ml-1 text-gray-700 hover:underline underline-offset-2" :text="reviewerName"></StxLink>
+        <StxLink x-to="`/user/${reviewerId}`" class="ml-1 text-gray-700 hover:underline underline-offset-2">{{ reviewerName }}</StxLink>
       </span>
-      <span :if="hasReviewerName && !hasReviewerLink()" class="text-gray-500" :text="`by ${reviewerName()}`"></span>
+      <span :if="hasReviewerName && !hasReviewerLink()" class="text-gray-500">{{ `by ${reviewerName()}` }}</span>
     </div>
 
     <!-- Judge byline. Medium-style author row: round avatar + name + court.
@@ -560,16 +558,14 @@
       />
       <div
         :if="!judgeImage"
-        class="flex items-center justify-center h-12 w-12 font-semibold text-amber-700 text-sm bg-amber-50 ring-1 ring-amber-200/60 rounded-full"
-        :text="judgeInitials"
-      ></div>
+        class="flex items-center justify-center h-12 w-12 font-semibold text-amber-700 text-sm bg-amber-50 ring-1 ring-amber-200/60 rounded-full">{{ judgeInitials }}</div>
       <div class="min-w-0 flex-1">
         <p class="font-semibold text-gray-900 text-sm">
           <span class="text-gray-400 font-normal">Review of</span>
-          <StxLink :if="judgeId" x-to="`/judges/${judgeId}/profile`" class="ml-1 text-gray-900 hover:underline underline-offset-2" :text="judgeName"></StxLink>
-          <span :if="!judgeId" :text="judgeName"></span>
+          <StxLink :if="judgeId" x-to="`/judges/${judgeId}/profile`" class="ml-1 text-gray-900 hover:underline underline-offset-2">{{ judgeName }}</StxLink>
+          <span :if="!judgeId">{{ judgeName }}</span>
         </p>
-        <p :if="judgeCourt" class="text-gray-500 text-xs mt-0.5" :text="judgeCourt"></p>
+        <p :if="judgeCourt" class="text-gray-500 text-xs mt-0.5">{{ judgeCourt }}</p>
       </div>
       <StxLink
         :if="judgeId"
@@ -619,7 +615,7 @@
       x-class="hasJudgeResponse() ? '' : 'hidden'"
     >
       <p class="font-semibold text-amber-800 text-xs tracking-widest uppercase">Official response</p>
-      <p class="mt-1 font-semibold text-gray-900 text-sm" :text="`From ${judgeResponseName()}`"></p>
+      <p class="mt-1 font-semibold text-gray-900 text-sm">{{ `From ${judgeResponseName()}` }}</p>
       <div class="article-body mt-3 text-base text-gray-800" x-html="judgeResponseBody"></div>
     </div>
 
@@ -643,10 +639,8 @@
           type="button"
           @click="postJudgeResponse()"
           x-disabled="judgeResponding"
-          class="px-4 py-2 font-semibold text-white text-sm bg-gray-900 hover:bg-gray-800 rounded-md disabled:opacity-50"
-          :text="judgeResponding() ? 'Posting…' : 'Post response'"
-        ></button>
-        <span class="text-red-700 text-xs" x-class="judgeRespondError() ? '' : 'hidden'" :text="judgeRespondError()"></span>
+          class="px-4 py-2 font-semibold text-white text-sm bg-gray-900 hover:bg-gray-800 rounded-md disabled:opacity-50">{{ judgeResponding() ? 'Posting…' : 'Post response' }}</button>
+        <span class="text-red-700 text-xs" x-class="judgeRespondError() ? '' : 'hidden'">{{ judgeRespondError() }}</span>
       </div>
     </div>
 
@@ -679,7 +673,7 @@
             <!-- Caption shifts based on count + own-like state so the
                  button reads naturally at 0, 1, and N — and credits the
                  reader directly when they're the one who reacted. -->
-            <span class="text-xs text-current/80" :text="liked ? (likes === 1 ? 'You find this helpful' : `You and ${likes - 1} ${likes === 2 ? 'other' : 'others'} find this helpful`) : (likes === 0 ? 'Be the first to find this helpful' : likes === 1 ? 'One person finds this helpful' : `${likes} people find this helpful`)"></span>
+            <span class="text-xs text-current/80">{{ liked ? (likes === 1 ? 'You find this helpful' : `You and ${likes - 1} ${likes === 2 ? 'other' : 'others'} find this helpful`) : (likes === 0 ? 'Be the first to find this helpful' : likes === 1 ? 'One person finds this helpful' : `${likes} people find this helpful`) }}</span>
           </button>
           <!-- Author view: read-only badge showing how readers reacted.
                Same icon + count + caption shape, no click handler, no
@@ -694,8 +688,8 @@
             <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
               <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
             </svg>
-            <span class="tabular-nums" :text="likes"></span>
-            <span class="text-xs text-gray-500" :text="likes === 0 ? 'No reactions yet' : likes === 1 ? '1 reader found this helpful' : `${likes} readers found this helpful`"></span>
+            <span class="tabular-nums">{{ likes }}</span>
+            <span class="text-xs text-gray-500">{{ likes === 0 ? 'No reactions yet' : likes === 1 ? '1 reader found this helpful' : `${likes} readers found this helpful` }}</span>
           </div>
         </div>
         <!-- Inline sign-in nudge (anonymous click). Soft prompt, no
@@ -714,9 +708,7 @@
         <div
           :if="likeError"
           role="alert"
-          class="px-3 py-1.5 text-red-800 text-xs bg-red-50 border border-red-200 rounded-md"
-          :text="likeError"
-        ></div>
+          class="px-3 py-1.5 text-red-800 text-xs bg-red-50 border border-red-200 rounded-md">{{ likeError }}</div>
       </div>
 
       <div class="flex items-center gap-4 text-gray-500 text-sm">
@@ -726,9 +718,7 @@
              the author check. -->
         <span
           class="hidden sm:inline-flex items-center px-2.5 py-1 font-medium text-xs ring-1 rounded-full capitalize"
-          x-class="isMine() ? statusBadgeClasses() : 'hidden'"
-          :text="statusLabel"
-        ></span>
+          x-class="isMine() ? statusBadgeClasses() : 'hidden'">{{ statusLabel }}</span>
         <StxLink x-to="`/reviews`" class="text-gray-600 hover:text-gray-900 hover:underline underline-offset-2">
           ← All reviews
         </StxLink>
@@ -762,7 +752,7 @@
           <div class="mt-2 space-y-1.5">
             <label :for="opt in flagReasonOptions" class="flex items-center gap-2 px-3 py-2 text-gray-700 text-sm bg-white border border-gray-200 hover:bg-gray-50 rounded-md cursor-pointer transition-colors">
               <input type="radio" name="flag_reason" x-model="flagReason" :value="opt.value">
-              <span :text="opt.label"></span>
+              <span>{{ opt.label }}</span>
             </label>
           </div>
         </div>
@@ -781,9 +771,7 @@
         <div
           role="alert"
           class="mt-3 px-3 py-2 text-red-800 text-xs bg-red-50 border border-red-200 rounded-md"
-          x-class="flagError() ? '' : 'hidden'"
-          :text="flagError()"
-        ></div>
+          x-class="flagError() ? '' : 'hidden'">{{ flagError() }}</div>
 
         <div
           role="status"
@@ -801,9 +789,7 @@
             type="button"
             @click="submitFlag()"
             x-disabled="flagSubmitting"
-            class="px-3 py-1.5 font-medium text-white text-sm bg-red-600 hover:bg-red-700 rounded-md disabled:opacity-50"
-            :text="flagSubmitting() ? 'Sending…' : 'Send report'"
-          ></button>
+            class="px-3 py-1.5 font-medium text-white text-sm bg-red-600 hover:bg-red-700 rounded-md disabled:opacity-50">{{ flagSubmitting() ? 'Sending…' : 'Send report' }}</button>
         </div>
       </div>
     </div>

--- a/resources/components/Bench/BenchComingSoon.stx
+++ b/resources/components/Bench/BenchComingSoon.stx
@@ -109,21 +109,19 @@
           </div>
           <button type="submit" x-disabled="loading"
             class="flex-none px-3.5 py-2.5 font-semibold text-sm text-white bg-gray-600 hover:bg-gray-500 rounded-md focus-visible:outline focus-visible:outline-2 focus-visible:outline-gray-600 focus-visible:outline-offset-2 shadow-sm"
-            :text="loading() ? 'Subscribing...' : 'Notify me'">
-            Notify me
-          </button>
+          >{{ loading() ? 'Subscribing...' : 'Notify me' }}</button>
         </form>
       </div>
       <div :if="successVisible()" @close="successVisible.set(false)">
         <Notification type="success" position="top-right" :show="true" :duration="0">
-          <p class="text-sm font-medium" :text="toastTitle()"></p>
-          <p class="mt-1 text-sm opacity-90" :text="toastMessage()"></p>
+          <p class="text-sm font-medium">{{ toastTitle() }}</p>
+          <p class="mt-1 text-sm opacity-90">{{ toastMessage() }}</p>
         </Notification>
       </div>
       <div :if="errorVisible()" @close="errorVisible.set(false)">
         <Notification type="error" position="top-right" :show="true" :duration="0">
-          <p class="text-sm font-medium" :text="toastTitle()"></p>
-          <p class="mt-1 text-sm opacity-90" :text="toastMessage()"></p>
+          <p class="text-sm font-medium">{{ toastTitle() }}</p>
+          <p class="mt-1 text-sm opacity-90">{{ toastMessage() }}</p>
         </Notification>
       </div>
     </div>

--- a/resources/components/Bench/BenchHeader.stx
+++ b/resources/components/Bench/BenchHeader.stx
@@ -335,8 +335,8 @@
           >
             <img class="h-8 w-8 rounded-full object-cover" x-src="judge.photo" x-alt="judge.name">
             <div class="flex-1 min-w-0">
-              <p class="font-medium text-gray-900 text-sm truncate" :text="judge.name"></p>
-              <p class="text-gray-500 text-xs truncate" :text="(judge.court && judge.court.name) ? judge.court.name : (judge.location || '')"></p>
+              <p class="font-medium text-gray-900 text-sm truncate">{{ judge.name }}</p>
+              <p class="text-gray-500 text-xs truncate">{{ (judge.court && judge.court.name) ? judge.court.name : (judge.location || '') }}</p>
             </div>
           </button>
         </div>
@@ -352,8 +352,8 @@
               <svg class="h-4 w-4 text-gray-500" viewBox="0 0 20 20" fill="currentColor"><path d="M10.394 2.08a1 1 0 00-.788 0l-7 3A1 1 0 003 7v11a1 1 0 001 1h12a1 1 0 001-1V7a1 1 0 00-.606-.92l-7-3zM5 9h2v6H5V9zm6 0h2v6h-2V9z"/></svg>
             </div>
             <div class="flex-1 min-w-0">
-              <p class="font-medium text-gray-900 text-sm truncate" :text="court.name"></p>
-              <p class="text-gray-500 text-xs truncate" :text="(court.city || '') + (court.state ? ', ' + court.state : '')"></p>
+              <p class="font-medium text-gray-900 text-sm truncate">{{ court.name }}</p>
+              <p class="text-gray-500 text-xs truncate">{{ (court.city || '') + (court.state ? ', ' + court.state : '') }}</p>
             </div>
           </button>
         </div>
@@ -408,9 +408,7 @@
                  would render even with zero unread. -->
             <span
               x-if="notifications.unreadCount()"
-              class="absolute -top-0.5 -right-0.5 inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 font-semibold text-[10px] text-white bg-red-500 rounded-full ring-2 ring-white"
-              :text="notifications.unreadCount() > 99 ? '99+' : notifications.unreadCount()"
-            ></span>
+              class="absolute -top-0.5 -right-0.5 inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 font-semibold text-[10px] text-white bg-red-500 rounded-full ring-2 ring-white">{{ notifications.unreadCount() > 99 ? '99+' : notifications.unreadCount() }}</span>
           </button>
 
           <!-- Dropdown panel. Same x-class-hidden treatment as the
@@ -449,8 +447,8 @@
                          unread; keeps the row scannable. -->
                     <span class="mt-1 inline-flex h-2 w-2 flex-shrink-0 rounded-full" x-class="n.unread ? 'bg-blue-500' : 'bg-transparent'"></span>
                     <div class="flex-1 min-w-0">
-                      <p class="text-gray-900 text-sm" :text="notificationLabel(n)"></p>
-                      <p class="mt-0.5 text-gray-400 text-xs" :text="relativeTime(n.created_at)"></p>
+                      <p class="text-gray-900 text-sm">{{ notificationLabel(n) }}</p>
+                      <p class="mt-0.5 text-gray-400 text-xs">{{ relativeTime(n.created_at) }}</p>
                     </div>
                   </button>
                 </li>
@@ -476,10 +474,8 @@
             x-aria-expanded="userMenuOpen() ? 'true' : 'false'"
           >
             <span
-              class="inline-flex items-center justify-center h-8 w-8 font-semibold text-amber-700 text-xs bg-amber-50 ring-1 ring-amber-200/60 rounded-full"
-              :text="userInitials"
-            ></span>
-            <span class="hidden sm:inline font-semibold text-gray-900 text-sm/6 max-w-[10rem] truncate" :text="userName"></span>
+              class="inline-flex items-center justify-center h-8 w-8 font-semibold text-amber-700 text-xs bg-amber-50 ring-1 ring-amber-200/60 rounded-full">{{ userInitials }}</span>
+            <span class="hidden sm:inline font-semibold text-gray-900 text-sm/6 max-w-[10rem] truncate">{{ userName }}</span>
             <svg
               class="hidden sm:block text-gray-400 transition-transform"
               x-class="userMenuOpen() ? 'rotate-180' : ''"
@@ -498,10 +494,10 @@
                  toggling between accounts don't fire an action against
                  the wrong session. -->
             <div class="flex gap-3 items-center px-4 py-3 border-b border-gray-100">
-              <span class="inline-flex items-center justify-center h-9 w-9 flex-shrink-0 font-semibold text-amber-700 text-xs bg-amber-50 ring-1 ring-amber-200/60 rounded-full" :text="userInitials"></span>
+              <span class="inline-flex items-center justify-center h-9 w-9 flex-shrink-0 font-semibold text-amber-700 text-xs bg-amber-50 ring-1 ring-amber-200/60 rounded-full">{{ userInitials }}</span>
               <div class="flex-1 min-w-0">
-                <p class="font-semibold text-gray-900 text-sm truncate" :text="userName"></p>
-                <p class="text-gray-500 text-xs truncate" :text="userEmail"></p>
+                <p class="font-semibold text-gray-900 text-sm truncate">{{ userName }}</p>
+                <p class="text-gray-500 text-xs truncate">{{ userEmail }}</p>
               </div>
             </div>
 

--- a/resources/components/Bench/Blog/BlogHeader.stx
+++ b/resources/components/Bench/Blog/BlogHeader.stx
@@ -9,7 +9,7 @@
 <header class="relative">
   <div class="mx-auto pb-8 pt-16 px-4 sm:px-6 lg:px-8 max-w-5xl">
     <div class="text-center">
-      <h1 class="font-bold text-4xl text-gray-900 tracking-tight sm:text-5xl" :text="post.title"></h1>
+      <h1 class="font-bold text-4xl text-gray-900 tracking-tight sm:text-5xl">{{ post.title }}</h1>
     </div>
 
     <!-- Author and meta info -->
@@ -19,16 +19,16 @@
         <img class="h-12 w-12 rounded-full" x-src="post.author.imageUrl" x-alt="post.author.name">
         <div class="ml-3">
           <p class="font-medium text-gray-900 text-sm">
-            <a href="#" class="hover:underline" :text="post.author.name"></a>
+            <a href="#" class="hover:underline">{{ post.author.name }}</a>
           </p>
         </div>
       </div>
 
       <!-- Reading time and date -->
       <div class="flex items-center space-x-4 text-gray-500 text-sm">
-        <span :text="readingTime"></span>
+        <span>{{ readingTime }}</span>
         <span aria-hidden="true">&middot;</span>
-        <time :datetime="post.dateTime" :text="post.date"></time>
+        <time :datetime="post.dateTime">{{ post.date }}</time>
       </div>
     </div>
   </div>

--- a/resources/components/Bench/CategoriesList.stx
+++ b/resources/components/Bench/CategoriesList.stx
@@ -68,8 +68,8 @@
       class="flex items-center px-3 py-2 font-medium text-sm rounded-md group"
       x-class="activeCategory === category.key ? 'bg-gray-100 text-gray-900' : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'"
     >
-      <span :text="category.label"></span>
-      <span class="inline-block ml-auto px-2 py-0.5 font-medium text-gray-600 text-xs bg-gray-100 rounded-full" :text="category.count"></span>
+      <span>{{ category.label }}</span>
+      <span class="inline-block ml-auto px-2 py-0.5 font-medium text-gray-600 text-xs bg-gray-100 rounded-full">{{ category.count }}</span>
     </a>
   </nav>
 </div>

--- a/resources/components/Bench/Comments.stx
+++ b/resources/components/Bench/Comments.stx
@@ -174,7 +174,7 @@
 
 <section class="mt-12 pt-8 border-t border-gray-200">
   <header class="flex items-end justify-between">
-    <h2 class="font-semibold text-gray-900 text-base" :text="`Comments (${comments().length})`"></h2>
+    <h2 class="font-semibold text-gray-900 text-base">{{ `Comments (${comments().length})` }}</h2>
   </header>
 
   <!-- Composer slot — one if/else-if/else chain (mutually exclusive,
@@ -199,9 +199,7 @@
     <div
       role="alert"
       class="mt-2 px-3 py-2 text-red-800 text-xs bg-red-50 border border-red-200 rounded-md"
-      x-class="commentError() ? '' : 'hidden'"
-      :text="commentError()"
-    ></div>
+      x-class="commentError() ? '' : 'hidden'">{{ commentError() }}</div>
 
     <div class="flex flex-wrap items-center justify-between gap-2 mt-3">
       <label class="flex gap-2 items-center text-gray-600 text-xs cursor-pointer">
@@ -215,7 +213,7 @@
         class="inline-flex items-center justify-center px-4 py-2 font-semibold text-white text-sm bg-gray-900 hover:bg-gray-800 rounded-md disabled:opacity-50"
       >
         <svg :if="commentSubmitting()" class="animate-spin -ml-0.5 mr-2 h-4 w-4" viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3" class="opacity-25"></circle><path d="M4 12a8 8 0 018-8" stroke="currentColor" stroke-width="3" stroke-linecap="round"></path></svg>
-        <span :text="commentSubmitting() ? 'Posting…' : 'Post comment'"></span>
+        <span>{{ commentSubmitting() ? 'Posting…' : 'Post comment' }}</span>
       </button>
     </div>
   </div>
@@ -257,15 +255,15 @@
   <ul :else class="space-y-4 mt-6">
     <li :for="c in comments" class="p-4 bg-white border border-gray-100 rounded-lg">
       <div class="flex items-start gap-3">
-        <span class="inline-flex flex-none items-center justify-center h-8 w-8 font-semibold text-amber-700 text-xs bg-amber-50 ring-1 ring-amber-200/60 rounded-full" :text="initialFor(c.author && c.author.name)"></span>
+        <span class="inline-flex flex-none items-center justify-center h-8 w-8 font-semibold text-amber-700 text-xs bg-amber-50 ring-1 ring-amber-200/60 rounded-full">{{ initialFor(c.author && c.author.name) }}</span>
         <div class="flex-1 min-w-0">
           <div class="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
             <!-- Linked when we have a real reviewer id (non-anonymous); plain text otherwise. -->
-            <StxLink :if="c.author && c.author.id" x-to="`/user/${c.author.id}`" class="font-medium text-gray-900 text-sm hover:underline underline-offset-2" :text="c.author.name"></StxLink>
-            <span :if="!(c.author && c.author.id)" class="font-medium text-gray-700 text-sm" :text="c.author && c.author.name || 'Anonymous reviewer'"></span>
-            <span class="text-gray-400 text-xs" :text="formatDate(c.created_at)"></span>
+            <StxLink :if="c.author && c.author.id" x-to="`/user/${c.author.id}`" class="font-medium text-gray-900 text-sm hover:underline underline-offset-2">{{ c.author.name }}</StxLink>
+            <span :if="!(c.author && c.author.id)" class="font-medium text-gray-700 text-sm">{{ c.author && c.author.name || 'Anonymous reviewer' }}</span>
+            <span class="text-gray-400 text-xs">{{ formatDate(c.created_at) }}</span>
           </div>
-          <p class="mt-1 leading-relaxed text-gray-700 text-sm" :text="c.body"></p>
+          <p class="mt-1 leading-relaxed text-gray-700 text-sm">{{ c.body }}</p>
           <button
             :if="isMyComment(c)"
             type="button"

--- a/resources/components/Bench/Court/CourtHeader.stx
+++ b/resources/components/Bench/Court/CourtHeader.stx
@@ -80,9 +80,9 @@
     <div class="flex gap-x-6 items-center">
       <img x-src="courtImage" x-alt="courtName" class="object-cover flex-none h-16 w-16 ring-1 ring-gray-900/10 rounded-lg">
       <div>
-        <div class="text-gray-500 text-sm/6">Courthouse <span class="text-gray-700" :text="`#${courtHeaderId}`"></span></div>
-        <h1 class="mt-1 font-semibold text-base text-gray-900" :text="courtName"></h1>
-        <p class="mt-0.5 text-gray-500 text-sm" :text="`${courtCity}${courtCity && courtState ? ', ' : ''}${courtState}`"></p>
+        <div class="text-gray-500 text-sm/6">Courthouse <span class="text-gray-700">{{ `#${courtHeaderId}` }}</span></div>
+        <h1 class="mt-1 font-semibold text-base text-gray-900">{{ courtName }}</h1>
+        <p class="mt-0.5 text-gray-500 text-sm">{{ `${courtCity}${courtCity && courtState ? ', ' : ''}${courtState}` }}</p>
       </div>
     </div>
   </div>

--- a/resources/components/Bench/Court/CourtHouseDirectory.stx
+++ b/resources/components/Bench/Court/CourtHouseDirectory.stx
@@ -136,7 +136,7 @@
         x-class="stateFilter === 'all' ? 'bg-gray-900 text-white border-gray-900' : 'bg-white text-gray-700 border-gray-200 hover:border-gray-300'"
       >
         All states
-        <span class="px-1.5 py-0.5 tabular-nums text-xs rounded" x-class="stateFilter === 'all' ? 'bg-white/15 text-white' : 'bg-gray-100 text-gray-600'" :text="courtCounts.byState.all"></span>
+        <span class="px-1.5 py-0.5 tabular-nums text-xs rounded" x-class="stateFilter === 'all' ? 'bg-white/15 text-white' : 'bg-gray-100 text-gray-600'">{{ courtCounts.byState.all }}</span>
       </button>
       <button :for="s in availableStates"
         type="button"
@@ -145,8 +145,8 @@
         class="inline-flex items-center gap-2 px-3 py-1.5 font-medium text-sm rounded-full border transition-colors"
         x-class="stateFilter === s ? 'bg-gray-900 text-white border-gray-900' : 'bg-white text-gray-700 border-gray-200 hover:border-gray-300'"
       >
-        <span :text="s"></span>
-        <span class="px-1.5 py-0.5 tabular-nums text-xs rounded" x-class="stateFilter === s ? 'bg-white/15 text-white' : 'bg-gray-100 text-gray-600'" :text="courtCounts.byState[s] || 0"></span>
+        <span>{{ s }}</span>
+        <span class="px-1.5 py-0.5 tabular-nums text-xs rounded" x-class="stateFilter === s ? 'bg-white/15 text-white' : 'bg-gray-100 text-gray-600'">{{ courtCounts.byState[s] || 0 }}</span>
       </button>
     </div>
 
@@ -168,7 +168,7 @@
         x-class="hasReviewsFilter === 'with' ? 'bg-gray-900 text-white border-gray-900' : 'bg-white text-gray-700 border-gray-200 hover:border-gray-300'"
       >
         With reviews
-        <span class="px-1.5 py-0.5 tabular-nums text-xs rounded" x-class="hasReviewsFilter === 'with' ? 'bg-white/15 text-white' : 'bg-emerald-50 text-emerald-700'" :text="courtCounts.withReviews"></span>
+        <span class="px-1.5 py-0.5 tabular-nums text-xs rounded" x-class="hasReviewsFilter === 'with' ? 'bg-white/15 text-white' : 'bg-emerald-50 text-emerald-700'">{{ courtCounts.withReviews }}</span>
       </button>
       <button
         type="button"
@@ -178,7 +178,7 @@
         x-class="hasReviewsFilter === 'without' ? 'bg-gray-900 text-white border-gray-900' : 'bg-white text-gray-700 border-gray-200 hover:border-gray-300'"
       >
         Without reviews
-        <span class="px-1.5 py-0.5 tabular-nums text-xs rounded" x-class="hasReviewsFilter === 'without' ? 'bg-white/15 text-white' : 'bg-gray-100 text-gray-600'" :text="courtCounts.withoutReviews"></span>
+        <span class="px-1.5 py-0.5 tabular-nums text-xs rounded" x-class="hasReviewsFilter === 'without' ? 'bg-white/15 text-white' : 'bg-gray-100 text-gray-600'">{{ courtCounts.withoutReviews }}</span>
       </button>
     </div>
 
@@ -213,16 +213,16 @@
             >
             <div class="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent"></div>
             <div class="absolute bottom-4 left-4">
-              <span class="inline-flex items-center px-3 py-1 font-medium text-gray-700 text-sm bg-white/90 ring-1 ring-gray-700/10 ring-inset rounded-full" :text="court.state"></span>
+              <span class="inline-flex items-center px-3 py-1 font-medium text-gray-700 text-sm bg-white/90 ring-1 ring-gray-700/10 ring-inset rounded-full">{{ court.state }}</span>
             </div>
           </div>
 
           <!-- Content Container -->
           <div class="p-6">
             <div class="text-center">
-              <h3 class="font-semibold text-gray-900 text-xl group-hover:text-deep-brown duration-200 transition-colors" :text="court.name"></h3>
-              <p class="mt-2 text-gray-500 text-sm" :text="`${court.city}, ${court.state}`"></p>
-              <p class="mt-1 text-gray-500 text-sm" :text="court.address"></p>
+              <h3 class="font-semibold text-gray-900 text-xl group-hover:text-deep-brown duration-200 transition-colors">{{ court.name }}</h3>
+              <p class="mt-2 text-gray-500 text-sm">{{ `${court.city}, ${court.state}` }}</p>
+              <p class="mt-1 text-gray-500 text-sm">{{ court.address }}</p>
             </div>
           </div>
       </StxLink>
@@ -236,7 +236,7 @@
       <svg class="mx-auto h-12 w-12 text-gray-300" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
         <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 21h16.5M4.5 3h15M5.25 3v18m13.5-18v18M9 6.75h1.5m-1.5 3h1.5m-1.5 3h1.5m3-6H15m-1.5 3H15m-1.5 3H15M9 21v-3.375c0-.621.504-1.125 1.125-1.125h3.75c.621 0 1.125.504 1.125 1.125V21" />
       </svg>
-      <p class="mt-4 font-medium text-gray-900" :text="(stateFilter() !== 'all' || hasReviewsFilter() !== 'all' || searchQuery() !== '') ? 'No courthouses match these filters' : 'No courthouses yet'"></p>
+      <p class="mt-4 font-medium text-gray-900">{{ (stateFilter() !== 'all' || hasReviewsFilter() !== 'all' || searchQuery() !== '') ? 'No courthouses match these filters' : 'No courthouses yet' }}</p>
       <p x-class="hasActiveFilters() ? '' : 'hidden'" class="mt-1 text-gray-500 text-sm">Try a different state, or clear the filters to see all courthouses.</p>
       <button
         x-class="hasActiveFilters() ? '' : 'hidden'"

--- a/resources/components/Bench/Court/CourtJudges.stx
+++ b/resources/components/Bench/Court/CourtJudges.stx
@@ -19,7 +19,7 @@
   <div class="flex items-center justify-between">
     <div>
       <h2 class="font-semibold text-2xl text-gray-900">Judges at this Court</h2>
-      <p class="mt-1 text-gray-500 text-sm" :text="`Active judges currently sitting at ${court.name}`"></p>
+      <p class="mt-1 text-gray-500 text-sm">{{ `Active judges currently sitting at ${court.name}` }}</p>
     </div>
     <div class="hidden sm:block">
       <select class="pl-3 pr-10 py-2 text-gray-900 sm:text-sm bg-white ring-1 ring-gray-300 ring-inset rounded-md focus:ring-2 focus:ring-gray-600 focus:ring-inset">
@@ -37,14 +37,14 @@
         <StxLink x-to="`/judges/${judge.id}/profile`" class="flex flex-1 gap-x-4 items-center min-w-0">
           <img class="object-cover flex-none h-12 w-12 rounded-full grayscale filter" x-src="judge.photo" x-alt="judge.name">
           <div class="flex-auto min-w-0">
-            <p class="font-semibold text-gray-900 text-sm hover:underline" :text="judge.name"></p>
-            <p class="mt-0.5 text-gray-500 text-xs truncate" :text="judge.department"></p>
+            <p class="font-semibold text-gray-900 text-sm hover:underline">{{ judge.name }}</p>
+            <p class="mt-0.5 text-gray-500 text-xs truncate">{{ judge.department }}</p>
           </div>
         </StxLink>
         <div class="flex gap-x-4 items-center sm:gap-x-6">
           <div class="hidden sm:flex sm:items-center">
             <Icon :for="star in stars" name="star" size="16" x-class="star <= judge.rating ? 'text-yellow-400' : 'text-gray-200'" />
-            <span class="ml-2 text-gray-500 text-xs" :text="judge.reviewCount"></span>
+            <span class="ml-2 text-gray-500 text-xs">{{ judge.reviewCount }}</span>
           </div>
           <StxLink x-to="`/judges/${judge.id}/profile`" class="font-semibold text-gray-700 text-sm hover:text-gray-900">
             View<span aria-hidden="true"> →</span>

--- a/resources/components/Bench/Court/CourtProfile.stx
+++ b/resources/components/Bench/Court/CourtProfile.stx
@@ -173,7 +173,7 @@
 
 <div class="lg:col-span-2 lg:row-end-2 lg:row-span-2 -mx-4 px-4 py-8 sm:mx-0 sm:pb-14 sm:px-8 xl:pb-20 xl:pt-16 xl:px-16 bg-white ring-1 ring-gray-900/5 sm:rounded-lg shadow-sm">
   <h2 class="font-semibold text-base text-gray-800">About this court</h2>
-  <p class="mt-4 leading-7 text-gray-600" :text="aboutText"></p>
+  <p class="mt-4 leading-7 text-gray-600">{{ aboutText }}</p>
 
   <dl class="grid grid-cols-1 sm:grid-cols-2 mt-8 text-sm/6">
     <div class="sm:pr-4">
@@ -204,22 +204,22 @@
     <dl class="grid gap-4 grid-cols-1 sm:grid-cols-3 mt-4">
       <div class="px-4 py-3 bg-off-gray rounded-lg">
         <dt class="text-gray-500 text-xs">Active Judges</dt>
-        <dd class="mt-1 font-semibold text-2xl text-gray-900" :text="activeJudges"></dd>
+        <dd class="mt-1 font-semibold text-2xl text-gray-900">{{ activeJudges }}</dd>
       </div>
       <div class="px-4 py-3 bg-off-gray rounded-lg">
         <dt class="text-gray-500 text-xs">Published Reviews</dt>
-        <dd class="mt-1 font-semibold text-2xl text-gray-900" :text="totalReviews"></dd>
+        <dd class="mt-1 font-semibold text-2xl text-gray-900">{{ totalReviews }}</dd>
       </div>
       <div class="px-4 py-3 bg-off-gray rounded-lg">
         <dt class="text-gray-500 text-xs">Avg Rating</dt>
-        <dd class="mt-1 font-semibold text-2xl text-gray-900" :text="avgRating"></dd>
+        <dd class="mt-1 font-semibold text-2xl text-gray-900">{{ avgRating }}</dd>
       </div>
     </dl>
   </div>
 
   <div class="mt-12">
     <h3 class="font-semibold text-base text-gray-800">Visit this court</h3>
-    <p class="mt-1 text-gray-500 text-xs" :text="courtAddress"></p>
+    <p class="mt-1 text-gray-500 text-xs">{{ courtAddress }}</p>
 
     <!-- Map host. Leaflet measures the element at construction time,
          so the explicit h-64 (256px) on the host is required — without

--- a/resources/components/Bench/Court/CourtReviews.stx
+++ b/resources/components/Bench/Court/CourtReviews.stx
@@ -54,20 +54,20 @@
       <div :for="review in courtReviews()" class="pb-8 border-b border-gray-200">
           <div class="flex items-center justify-between">
             <div class="flex items-center">
-              <div class="flex items-center justify-center h-10 w-10 font-semibold text-gray-500 text-sm bg-gray-100 rounded-full" :text="(review.title || 'A').slice(0, 1).toUpperCase()"></div>
+              <div class="flex items-center justify-center h-10 w-10 font-semibold text-gray-500 text-sm bg-gray-100 rounded-full">{{ (review.title || 'A').slice(0, 1).toUpperCase() }}</div>
               <div class="ml-4">
-                <h4 class="font-semibold text-gray-900 text-sm" :text="review.title"></h4>
+                <h4 class="font-semibold text-gray-900 text-sm">{{ review.title }}</h4>
                 <div class="flex items-center">
                   <div class="flex items-center">
                     <Icon :for="star in stars" name="star" size="16" x-class="star <= review.rating ? 'text-yellow-400' : 'text-gray-300'" />
                   </div>
-                  <span class="ml-2 text-gray-500 text-sm" :text="formatDate(review.created_at)"></span>
+                  <span class="ml-2 text-gray-500 text-sm">{{ formatDate(review.created_at) }}</span>
                 </div>
               </div>
             </div>
-            <span :if="review.type" class="inline-flex items-center px-2 py-1 font-medium text-xs text-gray-700 bg-gray-100 ring-1 ring-gray-200 ring-inset rounded-full" :text="review.type"></span>
+            <span :if="review.type" class="inline-flex items-center px-2 py-1 font-medium text-xs text-gray-700 bg-gray-100 ring-1 ring-gray-200 ring-inset rounded-full">{{ review.type }}</span>
           </div>
-          <p class="mt-3 leading-relaxed line-clamp-3 text-gray-700 text-sm" :text="review.content"></p>
+          <p class="mt-3 leading-relaxed line-clamp-3 text-gray-700 text-sm">{{ review.content }}</p>
           <div class="flex items-center justify-between mt-4">
             <StxLink x-to="`/judges/${review.judge_id}/profile`" class="text-gray-600 text-sm hover:underline">
               View judge →

--- a/resources/components/Bench/Feed.stx
+++ b/resources/components/Bench/Feed.stx
@@ -24,19 +24,19 @@
         </StxLink>
         <div class="ml-2">
           <p class="font-medium text-gray-900 text-sm">
-            <StxLink x-to="`/profile/${review.author.id}`" class="hover:underline" :text="review.author.name"></StxLink>
+            <StxLink x-to="`/profile/${review.author.id}`" class="hover:underline">{{ review.author.name }}</StxLink>
           </p>
           <p class="text-gray-500 text-xs">reviewed</p>
         </div>
       </div>
-      <span class="text-gray-600 text-sm" :text="review.date"></span>
+      <span class="text-gray-600 text-sm">{{ review.date }}</span>
     </div>
 
     <!-- Review Title and Content -->
     <div class="mt-3">
-      <h3 class="mb-2 font-bold text-gray-900 text-xl" :text="review.title"></h3>
+      <h3 class="mb-2 font-bold text-gray-900 text-xl">{{ review.title }}</h3>
       <div class="relative">
-        <p class="leading-relaxed line-clamp-3 text-base text-gray-700" :text="review.content"></p>
+        <p class="leading-relaxed line-clamp-3 text-base text-gray-700">{{ review.content }}</p>
         @include('Bench/BlurReview')
       </div>
     </div>
@@ -44,7 +44,7 @@
     <!-- Judge Name and Rating -->
     <div class="flex items-center justify-between mt-4">
       <div class="flex items-center space-x-3">
-        <StxLink x-to="`/judges/${review.judge.id}/profile`" class="font-semibold text-base text-gray-900 hover:underline" :text="review.judge.name"></StxLink>
+        <StxLink x-to="`/judges/${review.judge.id}/profile`" class="font-semibold text-base text-gray-900 hover:underline">{{ review.judge.name }}</StxLink>
         <div class="flex items-center">
           <Icon :for="star in stars" name="star" size="16" x-class="star <= review.rating ? 'text-yellow-400' : 'text-gray-300'" />
         </div>
@@ -57,7 +57,7 @@
           x-class="isLiked() ? 'text-blue-600' : 'text-gray-500 hover:text-gray-600'"
         >
           <Icon name="bookmark" size="20" class="mr-1.5 transition-colors" x-class="isLiked() ? 'text-blue-600' : 'text-gray-500 hover:text-gray-600'" />
-          <span x-class="isLiked() ? 'text-blue-600' : 'hover:text-gray-600'" :text="review.likes"></span>
+          <span x-class="isLiked() ? 'text-blue-600' : 'hover:text-gray-600'">{{ review.likes }}</span>
         </button>
         <StxLink
           x-to="`/article/${review.id}`"
@@ -70,8 +70,8 @@
 
     <!-- Status Tags -->
     <div class="flex items-center mt-4 space-x-2">
-      <span class="inline-flex items-center px-2 py-1 font-medium text-deepBrown text-xs bg-offBrown ring-1 ring-deepBrown/20 ring-inset rounded-full" :text="review.type"></span>
-      <span class="inline-flex items-center px-2 py-1 font-medium text-deepBrown text-xs bg-offBrown ring-1 ring-deepBrown/20 ring-inset rounded-full" :text="review.status"></span>
+      <span class="inline-flex items-center px-2 py-1 font-medium text-deepBrown text-xs bg-offBrown ring-1 ring-deepBrown/20 ring-inset rounded-full">{{ review.type }}</span>
+      <span class="inline-flex items-center px-2 py-1 font-medium text-deepBrown text-xs bg-offBrown ring-1 ring-deepBrown/20 ring-inset rounded-full">{{ review.status }}</span>
     </div>
   </div>
 

--- a/resources/components/Bench/Judge/Cases.stx
+++ b/resources/components/Bench/Judge/Cases.stx
@@ -107,21 +107,19 @@
             </thead>
             <tbody class="divide-gray-200 divide-y">
               <tr :for="case_ in cases">
-                  <td class="pl-4 pr-3 py-4 sm:pl-0 font-medium text-gray-900 text-sm whitespace-nowrap" :text="case_.number"></td>
-                  <td class="px-3 py-4 text-gray-500 text-sm whitespace-nowrap" :text="case_.title"></td>
+                  <td class="pl-4 pr-3 py-4 sm:pl-0 font-medium text-gray-900 text-sm whitespace-nowrap">{{ case_.number }}</td>
+                  <td class="px-3 py-4 text-gray-500 text-sm whitespace-nowrap">{{ case_.title }}</td>
                   <td class="px-3 py-4 text-gray-500 text-sm whitespace-nowrap">
-                    <span class="inline-flex items-center px-2 py-1 font-medium text-blue-700 text-xs bg-blue-50 ring-1 ring-blue-700/10 ring-inset rounded-md" :text="case_.type"></span>
+                    <span class="inline-flex items-center px-2 py-1 font-medium text-blue-700 text-xs bg-blue-50 ring-1 ring-blue-700/10 ring-inset rounded-md">{{ case_.type }}</span>
                   </td>
                   <td class="px-3 py-4 text-gray-500 text-sm whitespace-nowrap">
                     <span
                       class="inline-flex items-center rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset"
-                      x-class="statusClass(case_.status)"
-                      :text="case_.status"
-                    ></span>
+                      x-class="statusClass(case_.status)">{{ case_.status }}</span>
                   </td>
-                  <td class="px-3 py-4 text-gray-500 text-sm whitespace-nowrap" :text="case_.filedDate"></td>
+                  <td class="px-3 py-4 text-gray-500 text-sm whitespace-nowrap">{{ case_.filedDate }}</td>
                   <td class="relative pl-3 pr-4 py-4 sm:pr-0 font-medium text-right text-sm whitespace-nowrap">
-                    <a href="#" class="text-gray-600 hover:text-gray-900">View<span class="sr-only" :text="`, ${case_.number}`"></span></a>
+                    <a href="#" class="text-gray-600 hover:text-gray-900">View<span class="sr-only">{{ `, ${case_.number}` }}</span></a>
                   </td>
               </tr>
             </tbody>

--- a/resources/components/Bench/Judge/JudgeDirectory.stx
+++ b/resources/components/Bench/Judge/JudgeDirectory.stx
@@ -180,7 +180,7 @@
         x-class="practiceFilter === 'all' ? 'bg-gray-900 text-white border-gray-900' : 'bg-white text-gray-700 border-gray-200 hover:border-gray-300'"
       >
         All
-        <span class="px-1.5 py-0.5 tabular-nums text-xs rounded" x-class="practiceFilter === 'all' ? 'bg-white/15 text-white' : 'bg-gray-100 text-gray-600'" :text="practiceCounts.all"></span>
+        <span class="px-1.5 py-0.5 tabular-nums text-xs rounded" x-class="practiceFilter === 'all' ? 'bg-white/15 text-white' : 'bg-gray-100 text-gray-600'">{{ practiceCounts.all }}</span>
       </button>
       <button :for="area in PRACTICE_AREAS"
         type="button"
@@ -189,8 +189,8 @@
         class="inline-flex items-center gap-2 px-3 py-1.5 font-medium text-sm rounded-full border transition-colors capitalize"
         x-class="practiceFilter === area ? 'bg-gray-900 text-white border-gray-900' : 'bg-white text-gray-700 border-gray-200 hover:border-gray-300'"
       >
-        <span :text="area"></span>
-        <span class="px-1.5 py-0.5 tabular-nums text-xs rounded" x-class="practiceFilter === area ? 'bg-white/15 text-white' : 'bg-gray-100 text-gray-600'" :text="practiceCounts[area]"></span>
+        <span>{{ area }}</span>
+        <span class="px-1.5 py-0.5 tabular-nums text-xs rounded" x-class="practiceFilter === area ? 'bg-white/15 text-white' : 'bg-gray-100 text-gray-600'">{{ practiceCounts[area] }}</span>
       </button>
     </div>
 
@@ -230,9 +230,7 @@
         role="tab"
         @click="setStateFilter(s)"
         class="inline-flex items-center px-3 py-1.5 font-medium text-sm rounded-full border transition-colors"
-        x-class="stateFilter === s ? 'bg-gray-900 text-white border-gray-900' : 'bg-white text-gray-700 border-gray-200 hover:border-gray-300'"
-        :text="s"
-      ></button>
+        x-class="stateFilter === s ? 'bg-gray-900 text-white border-gray-900' : 'bg-white text-gray-700 border-gray-200 hover:border-gray-300'">{{ s }}</button>
     </div>
 
     <!-- Rating-threshold + activity filter rows. URL-driven via
@@ -325,15 +323,11 @@
             </div>
 
             <span
-              class="inline-flex items-center mt-3 px-3 py-1 font-medium text-gray-700 text-xs bg-gray-50 ring-1 ring-gray-200 ring-inset rounded-full"
-              :text="judge.court.name"
-            ></span>
+              class="inline-flex items-center mt-3 px-3 py-1 font-medium text-gray-700 text-xs bg-gray-50 ring-1 ring-gray-200 ring-inset rounded-full">{{ judge.court.name }}</span>
 
             <h3
-              class="mt-3 font-semibold text-gray-900 text-lg group-hover:text-gray-700 duration-200 transition-colors"
-              :text="judge.name"
-            ></h3>
-            <p class="mt-1 text-gray-500 text-sm" :text="judge.location"></p>
+              class="mt-3 font-semibold text-gray-900 text-lg group-hover:text-gray-700 duration-200 transition-colors">{{ judge.name }}</h3>
+            <p class="mt-1 text-gray-500 text-sm">{{ judge.location }}</p>
 
             <!-- Review aggregates are lazy-loaded by /api/judges/:id/reviews
                  when a profile opens — they're NOT included on the
@@ -353,7 +347,7 @@
       <svg class="mx-auto h-12 w-12 text-gray-300" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
         <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z" />
       </svg>
-      <p class="mt-4 font-medium text-gray-900" :text="(practiceFilter() !== 'all' || stateFilter() !== 'all' || ratingFilter() !== 'all' || hasReviewsFilter() !== 'all' || searchQuery() !== '') ? 'No judges match these filters' : 'No judges yet'"></p>
+      <p class="mt-4 font-medium text-gray-900">{{ (practiceFilter() !== 'all' || stateFilter() !== 'all' || ratingFilter() !== 'all' || hasReviewsFilter() !== 'all' || searchQuery() !== '') ? 'No judges match these filters' : 'No judges yet' }}</p>
       <p x-class="hasActiveFilters() ? '' : 'hidden'" class="mt-1 text-gray-500 text-sm">Try a different practice area or state, or clear the filters to see all judges.</p>
       <button
         x-class="hasActiveFilters() ? '' : 'hidden'"

--- a/resources/components/Bench/Judge/ProfileHeader.stx
+++ b/resources/components/Bench/Judge/ProfileHeader.stx
@@ -125,8 +125,8 @@
       <div class="flex gap-x-6 items-center">
         <img x-src="judgeImage" x-alt="judgeName" class="object-cover flex-none size-16 ring-1 ring-gray-900/10 rounded-full grayscale filter">
         <h1>
-          <div class="text-gray-500 text-sm/6">Judge <span class="text-gray-700" :text="`#${judgeId}`"></span></div>
-          <div class="mt-1 font-semibold text-base text-gray-900" :text="judgeName"></div>
+          <div class="text-gray-500 text-sm/6">Judge <span class="text-gray-700">{{ `#${judgeId}` }}</span></div>
+          <div class="mt-1 font-semibold text-base text-gray-900">{{ judgeName }}</div>
         </h1>
       </div>
       <div class="flex gap-x-4 items-center sm:gap-x-6">
@@ -149,8 +149,7 @@
               ? 'bg-white text-gray-900 ring-1 ring-gray-300 hover:bg-gray-50 focus-visible:outline-gray-300'
               : 'bg-gray-900 text-white hover:bg-gray-700 focus-visible:outline-gray-900'
           ]"
-          :text="followPending ? '…' : (isFollowing ? 'Following' : 'Follow')"
-        >Follow</button>
+        >{{ followPending ? '…' : (isFollowing ? 'Following' : 'Follow') }}</button>
 
         <div class="sm:hidden relative">
           <button type="button" class="block -m-3 p-3" @click="menuOpen.set(!menuOpen())" id="more-menu-button" aria-expanded="false" aria-haspopup="true">

--- a/resources/components/Bench/Judge/RecentRulings.stx
+++ b/resources/components/Bench/Judge/RecentRulings.stx
@@ -105,23 +105,21 @@
     <li :for="o in opinions" class="p-5 bg-white border border-gray-200 rounded-lg hover:border-gray-300 hover:shadow-sm transition-all">
       <div class="flex flex-wrap items-start justify-between gap-3">
         <div class="min-w-0 flex-1">
-          <h3 class="font-semibold text-gray-900 text-base" :text="o.case_name"></h3>
+          <h3 class="font-semibold text-gray-900 text-base">{{ o.case_name }}</h3>
           <div class="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1 text-gray-500 text-xs">
-            <span :if="o.decision_date" :text="formatDate(o.decision_date)"></span>
+            <span :if="o.decision_date">{{ formatDate(o.decision_date) }}</span>
             <span :if="o.decision_date && o.citation" class="text-gray-300">·</span>
-            <span :if="o.citation" class="font-mono text-gray-600" :text="o.citation"></span>
+            <span :if="o.citation" class="font-mono text-gray-600">{{ o.citation }}</span>
             <span :if="(o.decision_date || o.citation) && o.source_provider !== 'manual'" class="text-gray-300">·</span>
-            <span :if="o.source_provider !== 'manual'" class="text-gray-500" :text="`via ${o.source_provider}`"></span>
+            <span :if="o.source_provider !== 'manual'" class="text-gray-500">{{ `via ${o.source_provider}` }}</span>
           </div>
         </div>
         <span
           :if="o.outcome_label"
           class="inline-flex items-center px-2.5 py-0.5 font-medium text-xs ring-1 rounded-full capitalize whitespace-nowrap"
-          x-class="outcomeBadgeClasses(o.outcome_label)"
-          :text="o.outcome_label"
-        ></span>
+          x-class="outcomeBadgeClasses(o.outcome_label)">{{ o.outcome_label }}</span>
       </div>
-      <p :if="o.summary" class="mt-3 leading-relaxed text-gray-700 text-sm" :text="o.summary"></p>
+      <p :if="o.summary" class="mt-3 leading-relaxed text-gray-700 text-sm">{{ o.summary }}</p>
       <a
         :if="o.source_url"
         x-href="o.source_url"

--- a/resources/components/Bench/Judge/ReviewJudgeSearch.stx
+++ b/resources/components/Bench/Judge/ReviewJudgeSearch.stx
@@ -136,9 +136,9 @@
         >
           <img x-src="result.photo" class="object-cover flex-none h-10 w-10 ring-1 ring-gray-100 rounded-full grayscale filter" x-alt="result.name">
           <div class="min-w-0 flex-1">
-            <p class="font-medium text-gray-900 text-sm truncate" :text="result.name"></p>
-            <p class="text-gray-500 text-xs truncate" :text="result.court.name"></p>
-            <p :if="result.location" class="text-gray-400 text-xs truncate" :text="result.location"></p>
+            <p class="font-medium text-gray-900 text-sm truncate">{{ result.name }}</p>
+            <p class="text-gray-500 text-xs truncate">{{ result.court.name }}</p>
+            <p :if="result.location" class="text-gray-400 text-xs truncate">{{ result.location }}</p>
           </div>
           <svg class="h-4 w-4 text-gray-300 flex-none" viewBox="0 0 20 20" fill="currentColor">
             <path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd" />
@@ -148,7 +148,7 @@
     </div>
 
     <div :if="showEmpty" class="mt-2 p-4 text-center bg-gray-50 border border-gray-200 border-dashed rounded-md">
-      <p class="text-gray-600 text-sm">No judges match "<span :text="searchInput()"></span>".</p>
+      <p class="text-gray-600 text-sm">No judges match "<span>{{ searchInput() }}</span>".</p>
       <p class="mt-1 text-gray-400 text-xs">Try a different name or court.</p>
     </div>
   </div>

--- a/resources/components/Bench/Judge/Reviews.stx
+++ b/resources/components/Bench/Judge/Reviews.stx
@@ -52,12 +52,12 @@
   <!-- Header: summary if reviews exist, write-CTA always -->
   <div class="flex items-center justify-between">
     <div :if="reviewCount() > 0">
-      <h2 class="font-semibold text-2xl text-gray-900" :text="averageRating()"></h2>
+      <h2 class="font-semibold text-2xl text-gray-900">{{ averageRating() }}</h2>
       <div class="flex items-center">
         <div class="flex items-center">
           <Icon :for="star in stars" name="star" size="20" x-class="star <= Math.round(averageRating()) ? 'text-yellow-400' : 'text-gray-300'" />
         </div>
-        <p class="ml-2 text-gray-500 text-sm" :text="`Based on ${reviewCount()} review${reviewCount() === 1 ? '' : 's'}`"></p>
+        <p class="ml-2 text-gray-500 text-sm">{{ `Based on ${reviewCount()} review${reviewCount() === 1 ? '' : 's'}` }}</p>
       </div>
     </div>
     <div :if="reviewCount() === 0">
@@ -90,13 +90,13 @@
       <h3 class="font-semibold text-base text-gray-900">Rating Distribution</h3>
       <div class="mt-4 space-y-3">
         <div :for="bucket in ratingBuckets()" class="flex items-center">
-            <span class="text-gray-500 text-sm" :text="`${bucket.stars} stars`"></span>
+            <span class="text-gray-500 text-sm">{{ `${bucket.stars} stars` }}</span>
             <div class="flex-1 ml-4">
               <div class="h-2 bg-gray-200 rounded-full">
                 <div class="h-2 bg-yellow-400 rounded-full" x-style="`width: ${bucket.percentage}%`"></div>
               </div>
             </div>
-            <span class="ml-4 text-gray-500 text-sm" :text="`${bucket.percentage}%`"></span>
+            <span class="ml-4 text-gray-500 text-sm">{{ `${bucket.percentage}%` }}</span>
         </div>
       </div>
     </div>
@@ -107,14 +107,14 @@
         <div :for="review in reviews()" class="pb-8 border-b border-gray-200">
             <div class="flex items-center justify-between">
               <div class="flex items-center">
-                <div class="flex items-center justify-center h-10 w-10 font-semibold text-gray-500 text-sm bg-gray-100 rounded-full" :text="(review.title || 'A').slice(0, 1).toUpperCase()"></div>
+                <div class="flex items-center justify-center h-10 w-10 font-semibold text-gray-500 text-sm bg-gray-100 rounded-full">{{ (review.title || 'A').slice(0, 1).toUpperCase() }}</div>
                 <div class="ml-4">
-                  <h4 class="font-semibold text-gray-900 text-sm" :text="review.title"></h4>
+                  <h4 class="font-semibold text-gray-900 text-sm">{{ review.title }}</h4>
                   <div class="flex items-center">
                     <div class="flex items-center">
                       <Icon :for="star in stars" name="star" size="16" x-class="star <= review.rating ? 'text-yellow-400' : 'text-gray-300'" />
                     </div>
-                    <span class="ml-2 text-gray-500 text-sm" :text="formatDate(review.created_at)"></span>
+                    <span class="ml-2 text-gray-500 text-sm">{{ formatDate(review.created_at) }}</span>
                   </div>
                 </div>
               </div>
@@ -123,10 +123,10 @@
               </button>
             </div>
             <div class="mt-4 text-gray-500 text-sm">
-              <p :text="review.content"></p>
+              <p>{{ review.content }}</p>
             </div>
             <div class="flex items-center mt-4 space-x-4">
-              <button type="button" class="font-semibold text-gray-500 text-sm hover:text-gray-700" :text="`Helpful (${review.likes ?? 0})`"></button>
+              <button type="button" class="font-semibold text-gray-500 text-sm hover:text-gray-700">{{ `Helpful (${review.likes ?? 0})` }}</button>
             </div>
         </div>
       </div>

--- a/resources/components/Bench/JudgeSignup.stx
+++ b/resources/components/Bench/JudgeSignup.stx
@@ -116,7 +116,7 @@
   <div x-class="isAuthed() && phase() === 'claimed' ? '' : 'hidden'" class="mt-8 p-6 text-center bg-white border border-amber-200 rounded-2xl shadow-sm">
     <h2 class="font-serif font-bold text-2xl text-emerald-700">Claim submitted ✓</h2>
     <p class="mt-2 text-gray-700 text-sm">
-      Thanks — we've recorded your claim for <span class="font-semibold" :text="claimedName()"></span>. An admin will verify your identity before you can respond to reviews. We'll be in touch.
+      Thanks — we've recorded your claim for <span class="font-semibold">{{ claimedName() }}</span>. An admin will verify your identity before you can respond to reviews. We'll be in touch.
     </p>
     <StxLink to="/" class="inline-block mt-5 font-semibold text-gray-900 text-sm hover:underline underline-offset-4">← Back home</StxLink>
   </div>
@@ -144,10 +144,10 @@
           @click="pick(j)"
           class="flex w-full items-center gap-3 px-3 py-2 text-left hover:bg-gray-50"
         >
-          <span class="inline-flex flex-none items-center justify-center h-8 w-8 font-semibold text-amber-700 text-xs bg-amber-50 ring-1 ring-amber-200/60 rounded-full" :text="(j.name || '?').charAt(0)"></span>
+          <span class="inline-flex flex-none items-center justify-center h-8 w-8 font-semibold text-amber-700 text-xs bg-amber-50 ring-1 ring-amber-200/60 rounded-full">{{ (j.name || '?').charAt(0) }}</span>
           <span class="min-w-0">
-            <span class="block font-medium text-gray-900 text-sm" :text="j.name"></span>
-            <span class="block text-gray-500 text-xs" :text="j.location || (j.court ? j.court.name : '')"></span>
+            <span class="block font-medium text-gray-900 text-sm">{{ j.name }}</span>
+            <span class="block text-gray-500 text-xs">{{ j.location || (j.court ? j.court.name : '') }}</span>
           </span>
         </button>
       </li>
@@ -156,7 +156,7 @@
     <!-- Selected confirmation + submit -->
     <div x-class="hasSelection() ? '' : 'hidden'" class="mt-4 p-3 bg-amber-50/60 border border-amber-200 rounded-md">
       <p class="text-gray-700 text-sm">
-        Claiming: <span class="font-semibold" :text="selected() ? selected().name : ''"></span>
+        Claiming: <span class="font-semibold">{{ selected() ? selected().name : '' }}</span>
       </p>
       <button
         type="button"
@@ -165,16 +165,14 @@
         class="mt-3 inline-flex items-center justify-center px-4 py-2 font-semibold text-white text-sm bg-gray-900 hover:bg-gray-800 rounded-md disabled:opacity-50"
       >
         <svg :if="submitting()" class="animate-spin -ml-0.5 mr-2 h-4 w-4" viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3" class="opacity-25"></circle><path d="M4 12a8 8 0 018-8" stroke="currentColor" stroke-width="3" stroke-linecap="round"></path></svg>
-        <span :text="submitting() ? 'Submitting…' : 'Submit claim for verification'"></span>
+        <span>{{ submitting() ? 'Submitting…' : 'Submit claim for verification' }}</span>
       </button>
     </div>
 
     <div
       role="alert"
       x-class="errorMsg() ? '' : 'hidden'"
-      class="mt-3 px-3 py-2 text-red-800 text-xs bg-red-50 border border-red-200 rounded-md"
-      :text="errorMsg()"
-    ></div>
+      class="mt-3 px-3 py-2 text-red-800 text-xs bg-red-50 border border-red-200 rounded-md">{{ errorMsg() }}</div>
 
     <p class="mt-4 text-gray-400 text-xs leading-relaxed">
       Can't find your profile? It may not be in our directory yet. Contact us and we'll add it.

--- a/resources/components/Bench/LeftSidebar.stx
+++ b/resources/components/Bench/LeftSidebar.stx
@@ -15,8 +15,8 @@
         <div :for="judge in trendingJudges" class="flex items-center space-x-3">
             <img class="h-8 w-8 rounded-full grayscale filter" x-src="judge.photo" x-alt="judge.name" />
             <div class="flex-1 min-w-0">
-              <p class="font-medium text-gray-900 text-sm" :text="judge.name"></p>
-              <p class="text-gray-500 text-sm" :text="judge.court"></p>
+              <p class="font-medium text-gray-900 text-sm">{{ judge.name }}</p>
+              <p class="text-gray-500 text-sm">{{ judge.court }}</p>
             </div>
             <button type="button" class="font-semibold text-gray-900 text-xs hover:underline">Follow</button>
         </div>
@@ -36,15 +36,15 @@
                 <div class="flex relative space-x-3">
                   <div>
                     <span class="flex items-center justify-center h-8 w-8 bg-gray-400 ring-8 ring-white rounded-full">
-                      <span class="h-5 w-5 text-white" aria-hidden="true" :text="activity.icon"></span>
+                      <span class="h-5 w-5 text-white" aria-hidden="true">{{ activity.icon }}</span>
                     </span>
                   </div>
                   <div class="flex flex-1 justify-between pt-1.5 space-x-4 min-w-0">
                     <div>
-                      <p class="text-gray-500 text-sm" :text="activity.content"></p>
+                      <p class="text-gray-500 text-sm">{{ activity.content }}</p>
                     </div>
                     <div class="text-gray-500 text-right text-sm whitespace-nowrap">
-                      <time :datetime="activity.dateTime" :text="activity.date"></time>
+                      <time :datetime="activity.dateTime">{{ activity.date }}</time>
                     </div>
                   </div>
                 </div>

--- a/resources/components/Bench/MyReviewsView.stx
+++ b/resources/components/Bench/MyReviewsView.stx
@@ -151,7 +151,7 @@
         x-class="statusFilter === 'all' ? 'bg-gray-900 text-white border-gray-900' : 'bg-white text-gray-700 border-gray-200 hover:border-gray-300'"
       >
         All
-        <span class="px-1.5 py-0.5 tabular-nums text-xs rounded" x-class="statusFilter === 'all' ? 'bg-white/15 text-white' : 'bg-gray-100 text-gray-600'" :text="counts.all"></span>
+        <span class="px-1.5 py-0.5 tabular-nums text-xs rounded" x-class="statusFilter === 'all' ? 'bg-white/15 text-white' : 'bg-gray-100 text-gray-600'">{{ counts.all }}</span>
       </button>
       <button
         type="button"
@@ -161,7 +161,7 @@
         x-class="statusFilter === 'pending' ? 'bg-gray-900 text-white border-gray-900' : 'bg-white text-gray-700 border-gray-200 hover:border-gray-300'"
       >
         Pending
-        <span class="px-1.5 py-0.5 tabular-nums text-xs rounded" x-class="statusFilter === 'pending' ? 'bg-white/15 text-white' : 'bg-amber-50 text-amber-700'" :text="counts.pending"></span>
+        <span class="px-1.5 py-0.5 tabular-nums text-xs rounded" x-class="statusFilter === 'pending' ? 'bg-white/15 text-white' : 'bg-amber-50 text-amber-700'">{{ counts.pending }}</span>
       </button>
       <button
         type="button"
@@ -171,7 +171,7 @@
         x-class="statusFilter === 'published' ? 'bg-gray-900 text-white border-gray-900' : 'bg-white text-gray-700 border-gray-200 hover:border-gray-300'"
       >
         Published
-        <span class="px-1.5 py-0.5 tabular-nums text-xs rounded" x-class="statusFilter === 'published' ? 'bg-white/15 text-white' : 'bg-emerald-50 text-emerald-700'" :text="counts.published"></span>
+        <span class="px-1.5 py-0.5 tabular-nums text-xs rounded" x-class="statusFilter === 'published' ? 'bg-white/15 text-white' : 'bg-emerald-50 text-emerald-700'">{{ counts.published }}</span>
       </button>
       <button
         type="button"
@@ -181,7 +181,7 @@
         x-class="statusFilter === 'rejected' ? 'bg-gray-900 text-white border-gray-900' : 'bg-white text-gray-700 border-gray-200 hover:border-gray-300'"
       >
         Declined
-        <span class="px-1.5 py-0.5 tabular-nums text-xs rounded" x-class="statusFilter === 'rejected' ? 'bg-white/15 text-white' : 'bg-red-50 text-red-700'" :text="counts.rejected"></span>
+        <span class="px-1.5 py-0.5 tabular-nums text-xs rounded" x-class="statusFilter === 'rejected' ? 'bg-white/15 text-white' : 'bg-red-50 text-red-700'">{{ counts.rejected }}</span>
       </button>
     </div>
 
@@ -215,8 +215,8 @@
          initial load to avoid the "no reviews" flash before the
          first fetch returns. -->
     <div :if="profileStore.loaded && filtered.length === 0" class="mt-10 p-10 text-center bg-white border border-gray-200 rounded-lg">
-      <p class="font-semibold text-gray-900 text-base" :text="emptyTitle"></p>
-      <p class="mt-2 mx-auto max-w-md text-gray-500 text-sm" :text="emptyHint"></p>
+      <p class="font-semibold text-gray-900 text-base">{{ emptyTitle }}</p>
+      <p class="mt-2 mx-auto max-w-md text-gray-500 text-sm">{{ emptyHint }}</p>
       <StxLink to="/review" class="inline-flex items-center mt-6 px-4 py-2 font-medium text-white text-sm bg-gray-900 rounded-md hover:bg-gray-800">
         Write a review
       </StxLink>
@@ -231,14 +231,10 @@
         <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1">
           <StxLink
             x-to="`/article/${r.id}`"
-            class="font-semibold text-gray-900 text-base hover:underline underline-offset-2 decoration-gray-300"
-            :text="r.title"
-          ></StxLink>
+            class="font-semibold text-gray-900 text-base hover:underline underline-offset-2 decoration-gray-300">{{ r.title }}</StxLink>
           <span
             class="inline-flex items-center px-2 py-0.5 font-medium text-xs ring-1 rounded-full"
-            x-class="statusBadgeClasses(r.status)"
-            :text="statusLabel(r.status)"
-          ></span>
+            x-class="statusBadgeClasses(r.status)">{{ statusLabel(r.status) }}</span>
         </div>
 
         <div class="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1 text-gray-500 text-xs">
@@ -246,19 +242,17 @@
             Review of
             <StxLink
               x-to="`/judges/${r.judge.id}/profile`"
-              class="text-gray-700 hover:underline underline-offset-2"
-              :text="r.judge.name"
-            ></StxLink>
+              class="text-gray-700 hover:underline underline-offset-2">{{ r.judge.name }}</StxLink>
           </span>
           <span class="text-gray-300">·</span>
-          <span :text="formatDate(r.created_at)"></span>
+          <span>{{ formatDate(r.created_at) }}</span>
           <span class="text-gray-300">·</span>
-          <span class="inline-flex items-center gap-1 tabular-nums" :text="`${r.rating}/5`"></span>
+          <span class="inline-flex items-center gap-1 tabular-nums">{{ `${r.rating}/5` }}</span>
           <span :if="r.likes && r.likes > 0" class="text-gray-300">·</span>
-          <span :if="r.likes && r.likes > 0" class="inline-flex items-center gap-1" :text="`${r.likes} ${r.likes === 1 ? 'reaction' : 'reactions'}`"></span>
+          <span :if="r.likes && r.likes > 0" class="inline-flex items-center gap-1">{{ `${r.likes} ${r.likes === 1 ? 'reaction' : 'reactions'}` }}</span>
         </div>
 
-        <p class="mt-3 text-gray-600 text-sm line-clamp-2" :text="snippet(r.content)"></p>
+        <p class="mt-3 text-gray-600 text-sm line-clamp-2">{{ snippet(r.content) }}</p>
 
         <div class="flex flex-wrap items-center gap-x-4 mt-4 pt-3 border-t border-gray-100 text-sm">
           <StxLink x-to="`/article/${r.id}`" class="font-medium text-gray-900 hover:underline underline-offset-2">

--- a/resources/components/Bench/NotificationsView.stx
+++ b/resources/components/Bench/NotificationsView.stx
@@ -83,7 +83,7 @@
       <div>
         <h1 class="font-bold text-2xl text-gray-900">Notifications</h1>
         <p class="mt-1 text-gray-500 text-sm">
-          <span :text="store.unreadCount()"></span> unread
+          <span>{{ store.unreadCount() }}</span> unread
         </p>
       </div>
       <button
@@ -125,8 +125,8 @@
             <path d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
           </svg>
         </div>
-        <p class="font-semibold text-gray-900 text-sm" :text="emptyTitle()"></p>
-        <p class="mt-1 max-w-md mx-auto text-gray-500 text-xs leading-relaxed" :text="emptyHint()"></p>
+        <p class="font-semibold text-gray-900 text-sm">{{ emptyTitle() }}</p>
+        <p class="mt-1 max-w-md mx-auto text-gray-500 text-xs leading-relaxed">{{ emptyHint() }}</p>
       </div>
       <ul x-class="store.items().length > 0 ? 'divide-gray-100 divide-y' : 'hidden'">
         <li :for="n in store.items" class="hover:bg-gray-50">
@@ -137,9 +137,9 @@
           >
             <span class="mt-1 inline-flex h-2.5 w-2.5 flex-shrink-0 rounded-full" x-class="n.unread ? 'bg-blue-500' : 'bg-transparent'"></span>
             <div class="flex-1 min-w-0">
-              <p class="font-medium text-gray-900 text-sm" :text="labelFor(n)"></p>
-              <p class="mt-1 text-gray-500 text-xs" :text="detailFor(n)"></p>
-              <p class="mt-1 text-gray-400 text-xs" :text="relativeTime(n.created_at)"></p>
+              <p class="font-medium text-gray-900 text-sm">{{ labelFor(n) }}</p>
+              <p class="mt-1 text-gray-500 text-xs">{{ detailFor(n) }}</p>
+              <p class="mt-1 text-gray-400 text-xs">{{ relativeTime(n.created_at) }}</p>
             </div>
           </button>
         </li>

--- a/resources/components/Bench/PricingSection.stx
+++ b/resources/components/Bench/PricingSection.stx
@@ -43,7 +43,7 @@
         <p class="mt-4 text-gray-600 text-sm/6">Are you a clerk? This is for you.</p>
         <p class="flex gap-x-1 items-baseline mt-6">
           <span class="font-semibold text-4xl text-gray-800 tracking-tight">$0</span>
-          <span class="font-semibold text-gray-600 text-sm/6">/<span x-text="pricingPeriod() === 'monthly' ? 'month' : 'year'"></span></span>
+          <span class="font-semibold text-gray-600 text-sm/6">/<span>{{ pricingPeriod() === 'monthly' ? 'month' : 'year' }}</span></span>
         </p>
         <StxLink to="/register" aria-describedby="tier-free"
           class="block mt-6 px-2.5 py-1.5 font-semibold text-center text-gray-600 text-sm/6 ring-1 ring-gray-200 ring-inset rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-gray-600 focus-visible:outline-offset-2 hover:ring-gray-300">Get
@@ -63,8 +63,8 @@
         <h3 id="tier-hobby" class="font-semibold text-gray-600 text-lg/8">Professional</h3>
         <p class="mt-4 text-gray-600 text-sm/6">For anyone curious about judge reviews.</p>
         <p class="flex gap-x-1 items-baseline mt-6">
-          <span class="font-semibold text-4xl text-gray-800 tracking-tight">$<span x-text="pricingPeriod() === 'monthly' ? '10' : '60'"></span></span>
-          <span class="font-semibold text-gray-600 text-sm/6">/<span x-text="pricingPeriod() === 'monthly' ? 'month' : 'year'"></span></span>
+          <span class="font-semibold text-4xl text-gray-800 tracking-tight">$<span>{{ pricingPeriod() === 'monthly' ? '10' : '60' }}</span></span>
+          <span class="font-semibold text-gray-600 text-sm/6">/<span>{{ pricingPeriod() === 'monthly' ? 'month' : 'year' }}</span></span>
         </p>
         <StxLink to="/register" aria-describedby="tier-hobby"
           class="block mt-6 px-2.5 py-1.5 font-semibold text-center text-sm/6 text-white bg-gray-600 hover:bg-gray-500 rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-gray-600 focus-visible:outline-offset-2 shadow-sm">Get

--- a/resources/components/Bench/Profile/ProfileView.stx
+++ b/resources/components/Bench/Profile/ProfileView.stx
@@ -100,9 +100,9 @@
           <div class="flex gap-4 items-center">
             <img class="object-cover h-24 w-24 ring-2 ring-white/20 rounded-full" x-src="avatarUrl" x-alt="displayName" />
             <div>
-              <h1 class="font-bold text-2xl text-white" :text="displayName"></h1>
-              <p class="text-gray-400 text-sm" :text="userEmail"></p>
-              <p class="mt-1 text-gray-400 text-xs" :text="memberSince"></p>
+              <h1 class="font-bold text-2xl text-white">{{ displayName }}</h1>
+              <p class="text-gray-400 text-sm">{{ userEmail }}</p>
+              <p class="mt-1 text-gray-400 text-xs">{{ memberSince }}</p>
             </div>
           </div>
           <div class="flex flex-wrap gap-2">
@@ -117,19 +117,19 @@
     <div class="grid gap-4 grid-cols-2 mt-8 lg:grid-cols-4">
       <div class="p-6 bg-white border border-gray-200 rounded-xl">
         <p class="text-gray-500 text-sm">Total Reviews</p>
-        <p class="mt-1 font-semibold text-3xl text-gray-900" :text="profileStore.totalReviews"></p>
+        <p class="mt-1 font-semibold text-3xl text-gray-900">{{ profileStore.totalReviews }}</p>
       </div>
       <div class="p-6 bg-white border border-gray-200 rounded-xl">
         <p class="text-gray-500 text-sm">Judges Reviewed</p>
-        <p class="mt-1 font-semibold text-3xl text-gray-900" :text="profileStore.judgesReviewed"></p>
+        <p class="mt-1 font-semibold text-3xl text-gray-900">{{ profileStore.judgesReviewed }}</p>
       </div>
       <div class="p-6 bg-white border border-gray-200 rounded-xl">
         <p class="text-gray-500 text-sm">Average Rating</p>
-        <p class="mt-1 font-semibold text-3xl text-gray-900" :text="profileStore.averageRating || '—'"></p>
+        <p class="mt-1 font-semibold text-3xl text-gray-900">{{ profileStore.averageRating || '—' }}</p>
       </div>
       <div class="p-6 bg-white border border-gray-200 rounded-xl">
         <p class="text-gray-500 text-sm">Total Likes</p>
-        <p class="mt-1 font-semibold text-3xl text-gray-900" :text="profileStore.totalLikes"></p>
+        <p class="mt-1 font-semibold text-3xl text-gray-900">{{ profileStore.totalLikes }}</p>
       </div>
     </div>
 
@@ -163,15 +163,15 @@
             <div class="flex-none h-2 w-2 mt-2 bg-gray-900 rounded-full"></div>
             <div class="flex-1 min-w-0">
               <div class="flex flex-wrap items-baseline gap-x-2">
-                <StxLink x-to="`/article/${review.id}`" class="font-medium text-gray-900 text-sm hover:underline" :text="review.title"></StxLink>
+                <StxLink x-to="`/article/${review.id}`" class="font-medium text-gray-900 text-sm hover:underline">{{ review.title }}</StxLink>
                 <span :if="review.judge" class="text-gray-500 text-xs">
                   on
-                  <StxLink x-to="`/judges/${review.judge.id}/profile`" class="hover:underline" :text="review.judge.name"></StxLink>
+                  <StxLink x-to="`/judges/${review.judge.id}/profile`" class="hover:underline">{{ review.judge.name }}</StxLink>
                 </span>
               </div>
-              <p class="mt-0.5 text-gray-500 text-sm" :text="snippet(review.content)"></p>
+              <p class="mt-0.5 text-gray-500 text-sm">{{ snippet(review.content) }}</p>
               <div class="flex items-center gap-3 mt-1">
-                <span class="text-gray-400 text-xs" :text="relativeTime(review.created_at)"></span>
+                <span class="text-gray-400 text-xs">{{ relativeTime(review.created_at) }}</span>
                 <span :if="review.status === 'pending'" class="px-1.5 py-0.5 font-medium text-yellow-700 text-xs bg-yellow-50 ring-1 ring-yellow-200 rounded">Pending review</span>
               </div>
             </div>
@@ -186,8 +186,8 @@
           <li :for="j in suggestedJudges" class="flex gap-3 items-center">
             <img class="object-cover flex-none h-10 w-10 rounded-full grayscale filter" x-src="j.image_url || j.photo" x-alt="j.name" />
             <div class="flex-1 min-w-0">
-              <p class="font-medium text-gray-900 text-sm truncate" :text="j.name"></p>
-              <p class="text-gray-500 text-xs truncate" :text="(j.court && j.court.name) || j.court || ''"></p>
+              <p class="font-medium text-gray-900 text-sm truncate">{{ j.name }}</p>
+              <p class="text-gray-500 text-xs truncate">{{ (j.court && j.court.name) || j.court || '' }}</p>
             </div>
             <StxLink x-to="`/review/${j.id}`" class="flex-none px-2.5 py-1 font-medium text-gray-900 text-xs bg-gray-100 hover:bg-gray-200 rounded-md transition-colors">Review</StxLink>
           </li>

--- a/resources/components/Bench/ReviewForm.stx
+++ b/resources/components/Bench/ReviewForm.stx
@@ -375,7 +375,7 @@
     </div>
     <h2 class="mt-5 font-semibold text-xl text-gray-900">Thanks — your review is in.</h2>
     <p class="mt-2 leading-7 text-gray-600 text-sm max-w-md mx-auto">
-      Your review of <span class="font-medium text-gray-900" :text="submitted().judgeName"></span>
+      Your review of <span class="font-medium text-gray-900">{{ submitted().judgeName }}</span>
       is pending moderation. We typically publish within a day. You can see your reviews any time
       from your profile.
     </p>
@@ -393,7 +393,7 @@
     <div :if="submitted().reviewId" class="mt-8 pt-6 border-t border-gray-100 text-left max-w-md mx-auto">
       <div class="flex items-baseline justify-between mb-3">
         <h3 class="font-semibold text-gray-900 text-sm">Attach photos (optional)</h3>
-        <span class="text-gray-500 text-xs" :text="`${photoCount} / 4 attached`"></span>
+        <span class="text-gray-500 text-xs">{{ `${photoCount} / 4 attached` }}</span>
       </div>
       <p class="mb-3 text-gray-500 text-xs leading-relaxed">JPEG, PNG, or WebP up to 8MB each. Camera metadata (including GPS) is stripped at upload — your photos won't reveal where you were when you took them.</p>
 
@@ -418,12 +418,10 @@
       <div
         role="alert"
         class="mt-3 px-3 py-2 text-red-800 text-xs bg-red-50 border border-red-200 rounded-md"
-        x-class="photoError() ? '' : 'hidden'"
-        :text="photoError()"
-      ></div>
+        x-class="photoError() ? '' : 'hidden'">{{ photoError() }}</div>
 
       <p :if="photoUploading" class="mt-3 text-gray-500 text-xs">Uploading and resizing — this can take a few seconds per photo.</p>
-      <p :if="!photoUploading() && photoCount() > 0" class="mt-3 text-emerald-700 text-xs" :text="`${photoCount} ${photoCount() === 1 ? 'photo' : 'photos'} attached. You can add more or close this page — they'll appear on your review once moderation publishes it.`"></p>
+      <p :if="!photoUploading() && photoCount() > 0" class="mt-3 text-emerald-700 text-xs">{{ `${photoCount} ${photoCount() === 1 ? 'photo' : 'photos'} attached. You can add more or close this page — they'll appear on your review once moderation publishes it.` }}</p>
     </div>
   </div>
 
@@ -441,9 +439,9 @@
       <div class="flex gap-4 items-center">
         <img class="object-cover h-16 w-16 ring-2 ring-gray-100 rounded-full grayscale filter" x-src="judge().photo" x-alt="judge().name" />
         <div class="min-w-0">
-          <h3 class="font-semibold text-gray-900 text-lg" :text="judge().name"></h3>
-          <p class="text-gray-500 text-sm" :text="judge().court"></p>
-          <p :if="judge().department" class="text-gray-400 text-xs" :text="judge().department"></p>
+          <h3 class="font-semibold text-gray-900 text-lg">{{ judge().name }}</h3>
+          <p class="text-gray-500 text-sm">{{ judge().court }}</p>
+          <p :if="judge().department" class="text-gray-400 text-xs">{{ judge().department }}</p>
         </div>
       </div>
       <button
@@ -500,7 +498,7 @@
                 <Icon name="star" size="24" />
               </button>
             </div>
-            <span class="ml-2 w-24 text-gray-500 text-sm" :text="fairness() ? getRatingText(fairness()) : ''"></span>
+            <span class="ml-2 w-24 text-gray-500 text-sm">{{ fairness() ? getRatingText(fairness()) : '' }}</span>
           </div>
         </div>
 
@@ -521,7 +519,7 @@
                 <Icon name="star" size="24" />
               </button>
             </div>
-            <span class="ml-2 w-24 text-gray-500 text-sm" :text="knowledge() ? getRatingText(knowledge()) : ''"></span>
+            <span class="ml-2 w-24 text-gray-500 text-sm">{{ knowledge() ? getRatingText(knowledge()) : '' }}</span>
           </div>
         </div>
 
@@ -542,7 +540,7 @@
                 <Icon name="star" size="24" />
               </button>
             </div>
-            <span class="ml-2 w-24 text-gray-500 text-sm" :text="demeanor() ? getRatingText(demeanor()) : ''"></span>
+            <span class="ml-2 w-24 text-gray-500 text-sm">{{ demeanor() ? getRatingText(demeanor()) : '' }}</span>
           </div>
         </div>
       </div>
@@ -582,7 +580,7 @@
               <Icon name="star" size="32" />
             </button>
           </div>
-          <span class="ml-3 font-medium text-gray-700 text-sm" :text="ratingText()"></span>
+          <span class="ml-3 font-medium text-gray-700 text-sm">{{ ratingText() }}</span>
         </div>
       </div>
 
@@ -616,9 +614,7 @@
       role="alert"
       aria-live="polite"
       class="mb-4 p-3 text-red-700 text-sm bg-red-50 border border-red-200 rounded-md"
-      x-class="submitError() ? '' : 'hidden'"
-      :text="submitError()"
-    ></div>
+      x-class="submitError() ? '' : 'hidden'">{{ submitError() }}</div>
 
     <!-- Anonymity toggle (bench-review#36). Default OFF — anonymity
          is an explicit opt-in. Surfaces above the action bar so the
@@ -663,7 +659,7 @@
             ? 'bg-gray-900 hover:bg-gray-700'
             : 'bg-gray-300 cursor-not-allowed'
         ]"
-      ><svg :if="reviewsStore.submitting()" class="animate-spin -ml-0.5 mr-2 h-4 w-4" viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3" class="opacity-25"></circle><path d="M4 12a8 8 0 018-8" stroke="currentColor" stroke-width="3" stroke-linecap="round"></path></svg><span :text="reviewsStore.submitting() ? 'Submitting…' : 'Submit Review'"></span></button>
+      ><svg :if="reviewsStore.submitting()" class="animate-spin -ml-0.5 mr-2 h-4 w-4" viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3" class="opacity-25"></circle><path d="M4 12a8 8 0 018-8" stroke="currentColor" stroke-width="3" stroke-linecap="round"></path></svg><span>{{ reviewsStore.submitting() ? 'Submitting…' : 'Submit Review' }}</span></button>
     </div>
   </div>
 

--- a/resources/components/Bench/ReviewsFeed.stx
+++ b/resources/components/Bench/ReviewsFeed.stx
@@ -208,9 +208,7 @@
   <div
     role="alert"
     class="mb-4 px-3 py-2 text-red-800 text-sm bg-red-50 border border-red-200 rounded-md"
-    x-class="likeError() ? '' : 'hidden'"
-    :text="likeError()"
-  ></div>
+    x-class="likeError() ? '' : 'hidden'">{{ likeError() }}</div>
   <!-- Loading skeleton (bench-review#35). Renders three placeholder
        review cards matching the eventual layout (avatar circle + name
        line + meta line + 3-line body + footer chip row) so the feed
@@ -275,25 +273,25 @@
           </StxLink>
           <div class="ml-2">
             <p class="font-medium text-gray-900 text-sm">
-              <span :if="review.author.id === 0" :text="review.author.name"></span>
-              <StxLink :if="review.author.id !== 0" x-to="`/user/${review.author.id}`" class="hover:underline" :text="review.author.name"></StxLink>
+              <span :if="review.author.id === 0">{{ review.author.name }}</span>
+              <StxLink :if="review.author.id !== 0" x-to="`/user/${review.author.id}`" class="hover:underline">{{ review.author.name }}</StxLink>
             </p>
             <p class="text-gray-500 text-xs">reviewed</p>
           </div>
         </div>
-        <span class="text-gray-600 text-sm" :text="review.date"></span>
+        <span class="text-gray-600 text-sm">{{ review.date }}</span>
       </div>
 
       <!-- Title + content -->
       <div class="mt-3">
-        <h3 class="mb-2 font-bold text-gray-900 text-xl" :text="review.title"></h3>
+        <h3 class="mb-2 font-bold text-gray-900 text-xl">{{ review.title }}</h3>
         <p class="leading-relaxed line-clamp-3 text-base text-gray-700" x-html="review.content"></p>
       </div>
 
       <!-- Judge name + rating + actions -->
       <div class="flex items-center justify-between mt-4">
         <div class="flex items-center space-x-3">
-          <StxLink x-to="`/judges/${review.judge.id}/profile`" class="font-semibold text-base text-gray-900 hover:underline" :text="review.judge.name"></StxLink>
+          <StxLink x-to="`/judges/${review.judge.id}/profile`" class="font-semibold text-base text-gray-900 hover:underline">{{ review.judge.name }}</StxLink>
           <div class="flex items-center">
             <Icon :for="star in stars" name="star" size="16" x-class="star <= review.rating ? 'text-yellow-400' : 'text-gray-300'" />
           </div>
@@ -314,7 +312,7 @@
             <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="mr-1.5 transition-colors">
               <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
             </svg>
-            <span class="tabular-nums" :text="review.likes"></span>
+            <span class="tabular-nums">{{ review.likes }}</span>
           </button>
           <!-- Author: read-only count. Still shows the reaction
                total — it's useful feedback for the writer — but no
@@ -328,7 +326,7 @@
             <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="mr-1.5">
               <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
             </svg>
-            <span class="tabular-nums" :text="review.likes"></span>
+            <span class="tabular-nums">{{ review.likes }}</span>
           </span>
           <StxLink x-to="`/article/${review.id}`" class="text-gray-600 text-sm hover:text-gray-500 hover:underline">
             Read more

--- a/resources/components/Bench/SearchView.stx
+++ b/resources/components/Bench/SearchView.stx
@@ -91,10 +91,10 @@
       <div class="flex items-center justify-between mt-6">
         <div>
           <h1 class="font-semibold text-2xl text-gray-900">
-            <span :if="search.query" :text="`Results for &quot;${search.query}&quot;`"></span>
+            <span :if="search.query">{{ `Results for &quot;${search.query}&quot;` }}</span>
             <span :if="!search.query">All results</span>
           </h1>
-          <p class="mt-1 text-gray-600 text-sm" :text="totalResults + ' results found'"></p>
+          <p class="mt-1 text-gray-600 text-sm">{{ totalResults + ' results found' }}</p>
         </div>
       </div>
 
@@ -106,7 +106,7 @@
             class="px-1 py-3 font-medium text-sm whitespace-nowrap border-b-2"
             x-class="search.tab === 'all' ? 'border-gray-600 text-gray-900' : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700'"
           >
-            All <span class="ml-1 text-gray-400" :text="`(${totalResults})`"></span>
+            All <span class="ml-1 text-gray-400">{{ `(${totalResults})` }}</span>
           </button>
           <button
             type="button"
@@ -114,7 +114,7 @@
             class="px-1 py-3 font-medium text-sm whitespace-nowrap border-b-2"
             x-class="search.tab === 'judges' ? 'border-gray-600 text-gray-900' : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700'"
           >
-            Judges <span class="ml-1 text-gray-400" :text="`(${filteredJudges.length})`"></span>
+            Judges <span class="ml-1 text-gray-400">{{ `(${filteredJudges.length})` }}</span>
           </button>
           <button
             type="button"
@@ -122,7 +122,7 @@
             class="px-1 py-3 font-medium text-sm whitespace-nowrap border-b-2"
             x-class="search.tab === 'courts' ? 'border-gray-600 text-gray-900' : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700'"
           >
-            Courts <span class="ml-1 text-gray-400" :text="`(${filteredCourts.length})`"></span>
+            Courts <span class="ml-1 text-gray-400">{{ `(${filteredCourts.length})` }}</span>
           </button>
         </nav>
       </div>
@@ -133,7 +133,7 @@
         <svg class="mx-auto h-12 w-12 text-gray-300" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
           <path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
         </svg>
-        <p class="mt-4 font-medium text-gray-900" :text="`No results for &quot;${search.query}&quot;`"></p>
+        <p class="mt-4 font-medium text-gray-900">{{ `No results for &quot;${search.query}&quot;` }}</p>
         <p class="mt-1 text-gray-500 text-sm">Try a different name, court, or location.</p>
         <div class="flex gap-3 items-center justify-center mt-5">
           <StxLink to="/judges" class="inline-flex items-center px-4 py-2 font-medium text-white text-sm bg-gray-800 rounded-lg hover:bg-gray-700 transition-colors">Browse judges</StxLink>
@@ -155,13 +155,13 @@
             <StxLink x-to="`/judges/${judge.id}/profile`" class="flex flex-1 gap-x-4 items-center min-w-0">
               <img class="object-cover flex-none h-12 w-12 rounded-full grayscale filter" x-src="judge.photo" x-alt="judge.name">
               <div class="flex-auto min-w-0">
-                <p class="font-semibold text-gray-900 text-sm hover:underline" :text="judge.name"></p>
-                <p class="mt-0.5 text-gray-500 text-xs" :text="`${judge.court.name} · ${judge.location}`"></p>
+                <p class="font-semibold text-gray-900 text-sm hover:underline">{{ judge.name }}</p>
+                <p class="mt-0.5 text-gray-500 text-xs">{{ `${judge.court.name} · ${judge.location}` }}</p>
               </div>
             </StxLink>
             <div class="flex gap-x-2 items-center">
               <Icon :for="star in stars" name="star" size="16" x-class="star <= judge.rating ? 'text-yellow-400' : 'text-gray-200'" />
-              <span class="ml-1 text-gray-500 text-xs" :text="`(${judge.reviewCount})`"></span>
+              <span class="ml-1 text-gray-500 text-xs">{{ `(${judge.reviewCount})` }}</span>
             </div>
           </li>
         </ul>
@@ -187,8 +187,8 @@
               <div class="absolute inset-0 bg-gradient-to-t from-black/40 to-transparent"></div>
             </div>
             <div class="p-4">
-              <h3 class="font-semibold text-gray-900 text-sm group-hover:text-deep-brown" :text="court.name"></h3>
-              <p class="mt-1 text-gray-500 text-xs" :text="`${court.city}, ${court.state}`"></p>
+              <h3 class="font-semibold text-gray-900 text-sm group-hover:text-deep-brown">{{ court.name }}</h3>
+              <p class="mt-1 text-gray-500 text-xs">{{ `${court.city}, ${court.state}` }}</p>
             </div>
           </StxLink>
         </div>

--- a/resources/components/Bench/Settings/SettingsView.stx
+++ b/resources/components/Bench/Settings/SettingsView.stx
@@ -320,7 +320,7 @@
               x-class="photoUploading() ? 'opacity-60 pointer-events-none' : ''"
             >
               <svg :if="photoUploading()" class="animate-spin -ml-0.5 mr-2 h-4 w-4" viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3" class="opacity-25"></circle><path d="M4 12a8 8 0 018-8" stroke="currentColor" stroke-width="3" stroke-linecap="round"></path></svg>
-              <span :text="photoUploading() ? 'Uploading…' : 'Change photo'"></span>
+              <span>{{ photoUploading() ? 'Uploading…' : 'Change photo' }}</span>
               <input
                 type="file"
                 accept="image/jpeg,image/png,image/webp"
@@ -333,9 +333,7 @@
           <div
             role="alert"
             class="mt-2 text-red-600 text-xs"
-            x-class="photoError() ? '' : 'hidden'"
-            :text="photoError()"
-          ></div>
+            x-class="photoError() ? '' : 'hidden'">{{ photoError() }}</div>
         </div>
 
         <div class="grid gap-x-6 gap-y-5 grid-cols-1 sm:grid-cols-2">
@@ -369,7 +367,7 @@
         <div class="flex items-center justify-between gap-x-4 pt-2">
           <div>
             <p :if="saveStatus === 'saved'" class="text-emerald-700 text-sm">Saved.</p>
-            <p :if="saveStatus === 'error'" class="text-red-600 text-sm" :text="saveError"></p>
+            <p :if="saveStatus === 'error'" class="text-red-600 text-sm">{{ saveError }}</p>
           </div>
           <button
             type="button"
@@ -378,7 +376,7 @@
             class="inline-flex items-center justify-center px-4 py-2 font-semibold text-sm text-white bg-gray-900 hover:bg-gray-700 disabled:bg-gray-300 disabled:cursor-not-allowed rounded-md transition-colors shadow-sm"
           >
             <svg :if="saveStatus() === 'saving'" class="animate-spin -ml-0.5 mr-2 h-4 w-4" viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3" class="opacity-25"></circle><path d="M4 12a8 8 0 018-8" stroke="currentColor" stroke-width="3" stroke-linecap="round"></path></svg>
-            <span :text="saveStatus === 'saving' ? 'Saving…' : 'Save changes'"></span>
+            <span>{{ saveStatus === 'saving' ? 'Saving…' : 'Save changes' }}</span>
           </button>
         </div>
       </div>
@@ -435,7 +433,7 @@
         <div class="flex items-center justify-between gap-x-4 pt-2">
           <div>
             <p :if="pwStatus === 'saved'" class="text-emerald-700 text-sm">Password updated.</p>
-            <p :if="pwStatus === 'error'" class="text-red-600 text-sm" :text="pwError"></p>
+            <p :if="pwStatus === 'error'" class="text-red-600 text-sm">{{ pwError }}</p>
           </div>
           <button
             type="button"
@@ -444,7 +442,7 @@
             class="inline-flex items-center justify-center px-4 py-2 font-semibold text-sm text-white bg-gray-900 hover:bg-gray-700 disabled:bg-gray-300 disabled:cursor-not-allowed rounded-md transition-colors shadow-sm"
           >
             <svg :if="pwStatus() === 'saving'" class="animate-spin -ml-0.5 mr-2 h-4 w-4" viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3" class="opacity-25"></circle><path d="M4 12a8 8 0 018-8" stroke="currentColor" stroke-width="3" stroke-linecap="round"></path></svg>
-            <span :text="pwStatus === 'saving' ? 'Updating…' : 'Update password'"></span>
+            <span>{{ pwStatus === 'saving' ? 'Updating…' : 'Update password' }}</span>
           </button>
         </div>
       </div>
@@ -499,9 +497,7 @@
         <div
           role="alert"
           class="px-3 py-2 text-red-800 text-sm bg-red-50 border border-red-200 rounded-md"
-          x-class="credentialStatus === 'error' ? '' : 'hidden'"
-          :text="credentialError()"
-        ></div>
+          x-class="credentialStatus === 'error' ? '' : 'hidden'">{{ credentialError() }}</div>
 
         <div
           role="status"
@@ -517,7 +513,7 @@
             class="inline-flex items-center justify-center px-4 py-2 font-semibold text-white text-sm bg-gray-900 hover:bg-gray-800 rounded-md disabled:opacity-50"
           >
             <svg :if="credentialStatus() === 'saving'" class="animate-spin -ml-0.5 mr-2 h-4 w-4" viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3" class="opacity-25"></circle><path d="M4 12a8 8 0 018-8" stroke="currentColor" stroke-width="3" stroke-linecap="round"></path></svg>
-            <span :text="credentialStatus === 'saving' ? 'Submitting…' : 'Submit claim for verification'"></span>
+            <span>{{ credentialStatus === 'saving' ? 'Submitting…' : 'Submit claim for verification' }}</span>
           </button>
         </div>
       </div>
@@ -550,9 +546,7 @@
           type="button"
           @click="exportData()"
           x-disabled="exporting"
-          class="px-3 py-1.5 font-medium text-gray-700 text-sm bg-white hover:bg-gray-50 border border-gray-200 hover:border-gray-300 rounded-md transition-colors disabled:opacity-50"
-          :text="exporting() ? 'Preparing…' : 'Export data'"
-        ></button>
+          class="px-3 py-1.5 font-medium text-gray-700 text-sm bg-white hover:bg-gray-50 border border-gray-200 hover:border-gray-300 rounded-md transition-colors disabled:opacity-50">{{ exporting() ? 'Preparing…' : 'Export data' }}</button>
       </div>
 
       <!-- Delete account -->
@@ -580,7 +574,7 @@
             autocomplete="current-password"
             class="block mt-2 px-3 py-2 w-full max-w-sm text-gray-900 text-sm bg-white border border-gray-300 rounded-md focus:border-red-500 focus:outline-none focus:ring-2 focus:ring-red-200"
           >
-          <p role="alert" class="mt-2 text-red-700 text-xs" x-class="deleteError() ? '' : 'hidden'" :text="deleteError()"></p>
+          <p role="alert" class="mt-2 text-red-700 text-xs" x-class="deleteError() ? '' : 'hidden'">{{ deleteError() }}</p>
           <div class="flex gap-x-3 mt-3">
             <button
               type="button"
@@ -589,7 +583,7 @@
               class="inline-flex items-center justify-center px-4 py-2 font-semibold text-white text-sm bg-red-600 hover:bg-red-700 rounded-md disabled:opacity-50"
             >
               <svg :if="deleting()" class="animate-spin -ml-0.5 mr-2 h-4 w-4" viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3" class="opacity-25"></circle><path d="M4 12a8 8 0 018-8" stroke="currentColor" stroke-width="3" stroke-linecap="round"></path></svg>
-              <span :text="deleting() ? 'Deleting…' : 'Permanently delete'"></span>
+              <span>{{ deleting() ? 'Deleting…' : 'Permanently delete' }}</span>
             </button>
             <button
               type="button"

--- a/resources/components/Bench/ToastHost.stx
+++ b/resources/components/Bench/ToastHost.stx
@@ -17,8 +17,8 @@
     x-class="t.type === 'error' ? 'bg-red-50 border-red-200 text-red-800' : t.type === 'success' ? 'bg-green-50 border-green-200 text-green-800' : t.type === 'warning' ? 'bg-amber-50 border-amber-200 text-amber-900' : 'bg-white border-gray-200 text-gray-800'"
   >
     <div class="flex-1 min-w-0">
-      <p :if="t.title" class="font-semibold text-sm" :text="t.title"></p>
-      <p class="text-sm break-words" :text="t.message"></p>
+      <p :if="t.title" class="font-semibold text-sm">{{ t.title }}</p>
+      <p class="text-sm break-words">{{ t.message }}</p>
     </div>
     <span class="flex-shrink-0 text-lg leading-none opacity-40" aria-hidden="true">&times;</span>
   </div>

--- a/resources/components/Bench/User/ReviewerProfile.stx
+++ b/resources/components/Bench/User/ReviewerProfile.stx
@@ -189,10 +189,10 @@
       <div class="p-10">
         <div class="flex flex-col gap-6 sm:flex-row sm:items-center sm:justify-between">
           <div class="flex gap-4 items-center">
-            <span class="inline-flex items-center justify-center h-20 w-20 font-semibold text-amber-700 text-xl bg-amber-50 ring-2 ring-white/20 rounded-full" :text="initials"></span>
+            <span class="inline-flex items-center justify-center h-20 w-20 font-semibold text-amber-700 text-xl bg-amber-50 ring-2 ring-white/20 rounded-full">{{ initials }}</span>
             <div>
               <div class="flex flex-wrap items-center gap-2">
-                <h1 class="font-bold text-2xl text-white" :text="displayName"></h1>
+                <h1 class="font-bold text-2xl text-white">{{ displayName }}</h1>
                 <!-- Verified-credential badge (bench-review#37). Emerald
                      check pill, only rendered when the API surfaced a
                      non-null credential block (admin-approved). -->
@@ -207,9 +207,9 @@
                   Verified
                 </span>
               </div>
-              <p :if="memberSince" class="mt-1 text-gray-400 text-sm" :text="`Member since ${memberSince}`"></p>
-              <p :if="verifiedCredential" class="text-gray-400 text-xs" :text="credentialLabel"></p>
-              <p class="mt-1 text-gray-400 text-xs" :text="reviewCountLabel"></p>
+              <p :if="memberSince" class="mt-1 text-gray-400 text-sm">{{ `Member since ${memberSince}` }}</p>
+              <p :if="verifiedCredential" class="text-gray-400 text-xs">{{ credentialLabel }}</p>
+              <p class="mt-1 text-gray-400 text-xs">{{ reviewCountLabel }}</p>
             </div>
           </div>
           <div class="flex flex-wrap gap-2">
@@ -232,25 +232,25 @@
     <div class="grid gap-4 grid-cols-2 mt-8 lg:grid-cols-4">
       <div class="p-6 bg-white border border-gray-200 rounded-xl">
         <p class="text-gray-500 text-sm">Reviews</p>
-        <p class="mt-1 font-semibold text-3xl text-gray-900" :text="user()?.review_count ?? 0"></p>
+        <p class="mt-1 font-semibold text-3xl text-gray-900">{{ user()?.review_count ?? 0 }}</p>
       </div>
       <div class="p-6 bg-white border border-gray-200 rounded-xl">
         <p class="text-gray-500 text-sm">Judges Reviewed</p>
-        <p class="mt-1 font-semibold text-3xl text-gray-900" :text="user()?.judges_reviewed ?? 0"></p>
+        <p class="mt-1 font-semibold text-3xl text-gray-900">{{ user()?.judges_reviewed ?? 0 }}</p>
       </div>
       <div class="p-6 bg-white border border-gray-200 rounded-xl">
         <p class="text-gray-500 text-sm">Average Rating</p>
-        <p class="mt-1 font-semibold text-3xl text-gray-900" :text="user()?.avg_rating == null ? '—' : user().avg_rating"></p>
+        <p class="mt-1 font-semibold text-3xl text-gray-900">{{ user()?.avg_rating == null ? '—' : user().avg_rating }}</p>
       </div>
       <div class="p-6 bg-white border border-gray-200 rounded-xl">
         <p class="text-gray-500 text-sm">Total Likes</p>
-        <p class="mt-1 font-semibold text-3xl text-gray-900" :text="user()?.total_likes ?? 0"></p>
+        <p class="mt-1 font-semibold text-3xl text-gray-900">{{ user()?.total_likes ?? 0 }}</p>
       </div>
     </div>
 
     <!-- Reviews list -->
     <div class="mt-10">
-      <h2 class="font-semibold text-base text-gray-900" :text="`${displayName}'s published reviews`"></h2>
+      <h2 class="font-semibold text-base text-gray-900">{{ `${displayName}'s published reviews` }}</h2>
 
       <!-- Loading skeleton -->
       <ul :if="!reviewsLoaded" class="mt-6 space-y-4">
@@ -269,7 +269,7 @@
       <!-- Empty state -->
       <div :if="reviewsLoaded && reviews.length === 0" class="mt-6 p-10 text-center bg-white border border-gray-200 rounded-lg">
         <p class="font-semibold text-gray-900 text-base">No published reviews yet.</p>
-        <p class="mt-2 text-gray-500 text-sm" :text="isOwnProfile() ? 'When a moderator approves your first review, it lands here.' : 'This reviewer hasn\\'t had a review published yet.'"></p>
+        <p class="mt-2 text-gray-500 text-sm">{{ isOwnProfile() ? 'When a moderator approves your first review, it lands here.' : 'This reviewer hasn\\'t had a review published yet.' }}</p>
       </div>
 
       <!-- Reviews -->
@@ -278,22 +278,20 @@
           <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1">
             <StxLink
               x-to="`/article/${r.id}`"
-              class="font-semibold text-gray-900 text-base hover:underline underline-offset-2 decoration-gray-300"
-              :text="r.title"
-            ></StxLink>
+              class="font-semibold text-gray-900 text-base hover:underline underline-offset-2 decoration-gray-300">{{ r.title }}</StxLink>
             <span :if="r.judge" class="text-gray-500 text-xs">
               on
-              <StxLink x-to="`/judges/${r.judge.id}/profile`" class="text-gray-700 hover:underline underline-offset-2" :text="r.judge.name"></StxLink>
+              <StxLink x-to="`/judges/${r.judge.id}/profile`" class="text-gray-700 hover:underline underline-offset-2">{{ r.judge.name }}</StxLink>
             </span>
           </div>
           <div class="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1 text-gray-500 text-xs">
-            <span :text="formatDate(r.created_at)"></span>
+            <span>{{ formatDate(r.created_at) }}</span>
             <span class="text-gray-300">·</span>
-            <span class="inline-flex items-center gap-1 tabular-nums" :text="`${r.rating}/5`"></span>
+            <span class="inline-flex items-center gap-1 tabular-nums">{{ `${r.rating}/5` }}</span>
             <span :if="r.likes && r.likes > 0" class="text-gray-300">·</span>
-            <span :if="r.likes && r.likes > 0" class="inline-flex items-center gap-1" :text="`${r.likes} ${r.likes === 1 ? 'reaction' : 'reactions'}`"></span>
+            <span :if="r.likes && r.likes > 0" class="inline-flex items-center gap-1">{{ `${r.likes} ${r.likes === 1 ? 'reaction' : 'reactions'}` }}</span>
           </div>
-          <p class="mt-3 text-gray-600 text-sm line-clamp-2" :text="snippet(r.content)"></p>
+          <p class="mt-3 text-gray-600 text-sm line-clamp-2">{{ snippet(r.content) }}</p>
           <div class="flex flex-wrap items-center gap-x-4 mt-4 pt-3 border-t border-gray-100 text-sm">
             <StxLink x-to="`/article/${r.id}`" class="font-medium text-gray-900 hover:underline underline-offset-2">
               Read review →

--- a/resources/components/Bench/VerifyEmail.stx
+++ b/resources/components/Bench/VerifyEmail.stx
@@ -97,15 +97,13 @@
     <!-- Error (bad/expired link) -->
     <div x-class="phase() === 'error' ? '' : 'hidden'">
       <h1 class="font-serif font-bold text-2xl text-gray-900">Verification failed</h1>
-      <p class="mt-2 text-gray-600 text-sm" :text="message()"></p>
+      <p class="mt-2 text-gray-600 text-sm">{{ message() }}</p>
       <button
         type="button"
         @click="resend()"
         x-disabled="resending"
-        class="mt-5 inline-flex items-center px-4 py-2 font-semibold text-white text-sm bg-gray-900 hover:bg-gray-800 rounded-md disabled:opacity-50"
-        :text="resending() ? 'Sending…' : 'Resend verification email'"
-      ></button>
-      <p class="mt-3 text-gray-500 text-xs" :text="resendNote()"></p>
+        class="mt-5 inline-flex items-center px-4 py-2 font-semibold text-white text-sm bg-gray-900 hover:bg-gray-800 rounded-md disabled:opacity-50">{{ resending() ? 'Sending…' : 'Resend verification email' }}</button>
+      <p class="mt-3 text-gray-500 text-xs">{{ resendNote() }}</p>
     </div>
 
     <!-- Landing (arrived at /verify-email with no token) -->
@@ -116,10 +114,8 @@
         type="button"
         @click="resend()"
         x-disabled="resending"
-        class="mt-5 inline-flex items-center px-4 py-2 font-semibold text-gray-800 text-sm bg-white border border-gray-300 rounded-md hover:bg-gray-50 disabled:opacity-50"
-        :text="resending() ? 'Sending…' : 'Resend verification email'"
-      ></button>
-      <p class="mt-3 text-gray-500 text-xs" :text="resendNote()"></p>
+        class="mt-5 inline-flex items-center px-4 py-2 font-semibold text-gray-800 text-sm bg-white border border-gray-300 rounded-md hover:bg-gray-50 disabled:opacity-50">{{ resending() ? 'Sending…' : 'Resend verification email' }}</button>
+      <p class="mt-3 text-gray-500 text-xs">{{ resendNote() }}</p>
     </div>
   </div>
 </div>

--- a/resources/views/admin/login.stx
+++ b/resources/views/admin/login.stx
@@ -86,16 +86,13 @@
           role="alert"
           aria-live="polite"
           class="px-4 py-3 text-red-800 text-sm bg-red-50 border border-red-200 rounded-md"
-          x-class="submitError() ? '' : 'hidden'"
-          :text="submitError()"
-        ></div>
+          x-class="submitError() ? '' : 'hidden'">{{ submitError() }}</div>
 
         <button
           type="submit"
           x-disabled="loading"
           class="flex justify-center px-3 py-1.5 w-full font-semibold text-sm/6 text-white bg-gray-900 hover:bg-gray-800 rounded-md focus-visible:outline focus-visible:outline-2 focus-visible:outline-gray-900 focus-visible:outline-offset-2 disabled:opacity-50 disabled:cursor-not-allowed shadow-sm"
-          :text="loading() ? 'Signing in...' : 'Sign in to admin'"
-        >Sign in to admin</button>
+        >{{ loading() ? 'Signing in...' : 'Sign in to admin' }}</button>
       </form>
     </div>
 

--- a/resources/views/blog/index.stx
+++ b/resources/views/blog/index.stx
@@ -32,16 +32,16 @@
               </div>
               <div class="flex-1">
                 <div class="flex gap-x-4 items-center text-xs">
-                  <time :datetime="post.dateTime" class="text-gray-500" :text="post.date"></time>
+                  <time :datetime="post.dateTime" class="text-gray-500">{{ post.date }}</time>
                 </div>
                 <div class="relative max-w-xl group">
-                  <h3 class="mt-3 font-semibold leading-6 text-gray-900 text-lg group-hover:text-softBrown duration-200 transition-colors" :text="post.title"></h3>
+                  <h3 class="mt-3 font-semibold leading-6 text-gray-900 text-lg group-hover:text-softBrown duration-200 transition-colors">{{ post.title }}</h3>
                   <div class="flex gap-x-4 items-center mt-5">
                     <div class="leading-6 text-sm">
-                      <p class="font-semibold text-gray-900" :text="post.author.name"></p>
+                      <p class="font-semibold text-gray-900">{{ post.author.name }}</p>
                     </div>
                   </div>
-                  <p class="mt-5 leading-6 line-clamp-3 text-gray-600 text-sm" :text="post.content"></p>
+                  <p class="mt-5 leading-6 line-clamp-3 text-gray-600 text-sm">{{ post.content }}</p>
                 </div>
               </div>
             </article>

--- a/resources/views/contact.stx
+++ b/resources/views/contact.stx
@@ -148,7 +148,7 @@
               </div>
             </div>
 
-            <p x-class="submitError() ? 'text-red-600 text-sm' : 'hidden'" :text="submitError()"></p>
+            <p x-class="submitError() ? 'text-red-600 text-sm' : 'hidden'">{{ submitError() }}</p>
 
             <button
               type="submit"

--- a/resources/views/court-houses/[id].stx
+++ b/resources/views/court-houses/[id].stx
@@ -31,8 +31,8 @@
             <div class="flex gap-x-6 items-center">
               <img x-src="court.image" x-alt="court.name" class="object-cover flex-none h-16 w-16 ring-1 ring-gray-900/10 rounded-lg">
               <h1>
-                <div class="text-gray-500 text-sm/6">Court House <span class="text-gray-700" :text="`#${court.id}`"></span></div>
-                <div class="mt-1 font-semibold text-base text-gray-900" :text="court.name"></div>
+                <div class="text-gray-500 text-sm/6">Court House <span class="text-gray-700">{{ `#${court.id}` }}</span></div>
+                <div class="mt-1 font-semibold text-base text-gray-900">{{ court.name }}</div>
               </h1>
             </div>
             <div class="flex gap-x-4 items-center sm:gap-x-6">
@@ -91,15 +91,15 @@
               <div class="p-4">
                 <dl class="flex flex-wrap">
                   <div class="flex-auto">
-                    <dt class="font-semibold text-gray-900 text-sm/6" :text="court.name"></dt>
-                    <dd class="mt-1 text-gray-700 text-sm" :text="`${court.city}, ${court.state}`"></dd>
+                    <dt class="font-semibold text-gray-900 text-sm/6">{{ court.name }}</dt>
+                    <dd class="mt-1 text-gray-700 text-sm">{{ `${court.city}, ${court.state}` }}</dd>
                   </div>
                   <div class="flex flex-none gap-x-4 mt-6 pt-6 px-2 w-full border-gray-900/5 border-t">
                     <dt class="flex-none">
                       <span class="sr-only">Address</span>
                       <Icon name="map-pin" size="20" class="text-gray-400" />
                     </dt>
-                    <dd class="text-gray-700 text-sm/6" :text="`${court.address} ${court.city}, ${court.state} ${court.zipCode}`"></dd>
+                    <dd class="text-gray-700 text-sm/6">{{ `${court.address} ${court.city}, ${court.state} ${court.zipCode}` }}</dd>
                   </div>
                   <div class="flex flex-none gap-x-4 mt-4 px-2 w-full">
                     <dt class="flex-none">

--- a/resources/views/faq.stx
+++ b/resources/views/faq.stx
@@ -67,14 +67,14 @@
               class="flex items-center justify-between w-full text-gray-900 text-left"
               @click="open.set(open() === idx ? -1 : idx)"
             >
-              <span class="font-semibold text-base" :text="faq.q"></span>
+              <span class="font-semibold text-base">{{ faq.q }}</span>
               <span class="flex items-center ml-6 h-7">
                 <Icon name="chevron-down" size="24" class="duration-200 transition-transform" x-class="open() === idx ? 'rotate-180' : ''" />
               </span>
             </button>
           </dt>
           <dd :if="open() === idx" class="mt-4 pr-12">
-            <p class="leading-7 text-base text-gray-600" :text="faq.a"></p>
+            <p class="leading-7 text-base text-gray-600">{{ faq.a }}</p>
           </dd>
       </div>
     </dl>

--- a/resources/views/forgot-password.stx
+++ b/resources/views/forgot-password.stx
@@ -74,7 +74,7 @@
             </div>
           </div>
 
-          <p :if="submitError()" class="text-red-600 text-sm" :text="submitError()"></p>
+          <p :if="submitError()" class="text-red-600 text-sm">{{ submitError() }}</p>
 
           <button
             type="submit"
@@ -94,7 +94,7 @@
         </div>
         <h2 class="mt-4 font-semibold text-gray-900 text-lg">Check your email</h2>
         <p class="mt-2 text-gray-600 text-sm">
-          If an account exists for <span class="font-medium" :text="email"></span>, we've sent a password reset link.
+          If an account exists for <span class="font-medium">{{ email }}</span>, we've sent a password reset link.
         </p>
       </div>
 

--- a/resources/views/home.stx
+++ b/resources/views/home.stx
@@ -181,7 +181,7 @@
         </form>
         <div class="flex flex-wrap gap-2 mt-4 text-gray-500 text-xs">
           <span class="font-medium">Popular:</span>
-          <StxLink :for="cat in popularCategories" x-to="`/search?type=${cat.name}`" class="hover:text-gray-700 hover:underline" :text="cat.name"></StxLink>
+          <StxLink :for="cat in popularCategories" x-to="`/search?type=${cat.name}`" class="hover:text-gray-700 hover:underline">{{ cat.name }}</StxLink>
         </div>
       </div>
     </div>
@@ -241,13 +241,13 @@
             <div class="flex gap-4 items-center">
               <img class="object-cover h-14 w-14 ring-2 ring-gray-50 rounded-full grayscale group-hover:grayscale-0 duration-200 transition-all" x-src="judge.image_url" x-alt="judge.name">
               <div class="min-w-0 flex-1">
-                <h3 class="font-semibold text-gray-900 truncate" :text="judge.name"></h3>
-                <p :if="judge.court_name" class="text-gray-500 text-sm truncate" :text="judge.court_name"></p>
+                <h3 class="font-semibold text-gray-900 truncate">{{ judge.name }}</h3>
+                <p :if="judge.court_name" class="text-gray-500 text-sm truncate">{{ judge.court_name }}</p>
               </div>
             </div>
             <div class="flex items-center justify-between mt-4 pt-3 border-t border-gray-100">
-              <span class="text-amber-700 text-xs font-medium" :text="`${judge.review_count} ${judge.review_count === 1 ? 'review' : 'reviews'} this week`"></span>
-              <span :if="judge.avg_rating" class="font-medium text-gray-700 text-xs tabular-nums" :text="`${judge.avg_rating} ★`"></span>
+              <span class="text-amber-700 text-xs font-medium">{{ `${judge.review_count} ${judge.review_count === 1 ? 'review' : 'reviews'} this week` }}</span>
+              <span :if="judge.avg_rating" class="font-medium text-gray-700 text-xs tabular-nums">{{ `${judge.avg_rating} ★` }}</span>
             </div>
           </StxLink>
         </div>
@@ -264,8 +264,8 @@
       <div class="mx-auto px-4 sm:px-6 lg:px-8 max-w-7xl">
         <div class="flex items-end justify-between">
           <div>
-            <h2 class="font-bold text-3xl text-gray-900 tracking-tight" :text="showTopRated() ? 'Top-rated judges' : 'Featured judges'"></h2>
-            <p class="mt-2 text-gray-600" :text="showTopRated() ? 'Highest-rated judges based on published reviews.' : 'A sampling from the directory to get you started.'"></p>
+            <h2 class="font-bold text-3xl text-gray-900 tracking-tight">{{ showTopRated() ? 'Top-rated judges' : 'Featured judges' }}</h2>
+            <p class="mt-2 text-gray-600">{{ showTopRated() ? 'Highest-rated judges based on published reviews.' : 'A sampling from the directory to get you started.' }}</p>
           </div>
           <StxLink to="/judges" class="hidden sm:block font-semibold text-gray-700 text-sm hover:text-gray-900">
             View all judges <span aria-hidden="true">→</span>
@@ -283,12 +283,12 @@
             <div class="flex gap-4 items-center">
               <img class="object-cover h-16 w-16 ring-2 ring-gray-50 rounded-full grayscale group-hover:grayscale-0 duration-200 transition-all" x-src="judge.image_url" x-alt="judge.name">
               <div class="min-w-0">
-                <h3 class="font-semibold text-gray-900 truncate group-hover:text-deep-brown duration-200 transition-colors" :text="judge.name"></h3>
-                <p :if="judge.court_name" class="text-gray-500 text-sm truncate" :text="judge.court_name"></p>
+                <h3 class="font-semibold text-gray-900 truncate group-hover:text-deep-brown duration-200 transition-colors">{{ judge.name }}</h3>
+                <p :if="judge.court_name" class="text-gray-500 text-sm truncate">{{ judge.court_name }}</p>
               </div>
             </div>
             <div class="flex items-center justify-between mt-4 pt-4 border-gray-100 border-t">
-              <span class="font-medium text-amber-700 text-xs tabular-nums" :text="`${judge.avg_rating} ★  · ${judge.review_count} ${judge.review_count === 1 ? 'review' : 'reviews'}`"></span>
+              <span class="font-medium text-amber-700 text-xs tabular-nums">{{ `${judge.avg_rating} ★  · ${judge.review_count} ${judge.review_count === 1 ? 'review' : 'reviews'}` }}</span>
               <span class="font-medium text-gray-700 text-xs hover:text-gray-900">View profile →</span>
             </div>
           </StxLink>
@@ -306,9 +306,9 @@
             <div class="flex gap-4 items-center">
               <img class="object-cover h-16 w-16 ring-2 ring-gray-50 rounded-full grayscale group-hover:grayscale-0 duration-200 transition-all" x-src="judge.photo" x-alt="judge.name">
               <div class="min-w-0">
-                <h3 class="font-semibold text-gray-900 truncate group-hover:text-deep-brown duration-200 transition-colors" :text="judge.name"></h3>
-                <p class="text-gray-500 text-sm truncate" :text="judge.court.name"></p>
-                <p class="text-gray-400 text-xs" :text="judge.location"></p>
+                <h3 class="font-semibold text-gray-900 truncate group-hover:text-deep-brown duration-200 transition-colors">{{ judge.name }}</h3>
+                <p class="text-gray-500 text-sm truncate">{{ judge.court.name }}</p>
+                <p class="text-gray-400 text-xs">{{ judge.location }}</p>
               </div>
             </div>
             <div class="flex items-center justify-between mt-4 pt-4 border-gray-100 border-t">
@@ -398,18 +398,18 @@
         >
             <div class="flex items-center justify-between">
               <div class="flex items-center">
-                <div class="flex items-center justify-center h-9 w-9 font-semibold text-gray-500 text-sm bg-gray-100 rounded-full" :text="(review.title || 'A').slice(0, 1).toUpperCase()"></div>
+                <div class="flex items-center justify-center h-9 w-9 font-semibold text-gray-500 text-sm bg-gray-100 rounded-full">{{ (review.title || 'A').slice(0, 1).toUpperCase() }}</div>
                 <div class="ml-3">
                   <p class="font-medium text-gray-900 text-sm">Reviewer</p>
-                  <p class="text-gray-500 text-xs" :text="formatDate(review.created_at)"></p>
+                  <p class="text-gray-500 text-xs">{{ formatDate(review.created_at) }}</p>
                 </div>
               </div>
               <div class="flex items-center">
                 <Icon :for="star in stars" name="star" size="16" x-class="star <= review.rating ? 'text-yellow-400' : 'text-gray-200'" />
               </div>
             </div>
-            <h3 class="mt-4 font-semibold line-clamp-2 text-gray-900" :text="review.title"></h3>
-            <p class="mt-2 line-clamp-3 text-gray-600 text-sm" :text="review.content"></p>
+            <h3 class="mt-4 font-semibold line-clamp-2 text-gray-900">{{ review.title }}</h3>
+            <p class="mt-2 line-clamp-3 text-gray-600 text-sm">{{ review.content }}</p>
         </StxLink>
       </div>
     </div>
@@ -433,10 +433,10 @@
         <ul class="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-5">
           <li :for="reviewer in activeReviewers" class="p-4 bg-white border border-gray-100 rounded-xl hover:border-emerald-200 hover:shadow-sm transition-all">
             <StxLink x-to="`/user/${reviewer.id}`" class="flex items-center gap-3">
-              <div class="flex items-center justify-center flex-none h-10 w-10 font-semibold text-emerald-700 text-xs bg-emerald-50 ring-1 ring-emerald-200/60 rounded-full" :text="(reviewer.name || '?').charAt(0).toUpperCase()"></div>
+              <div class="flex items-center justify-center flex-none h-10 w-10 font-semibold text-emerald-700 text-xs bg-emerald-50 ring-1 ring-emerald-200/60 rounded-full">{{ (reviewer.name || '?').charAt(0).toUpperCase() }}</div>
               <div class="min-w-0 flex-1">
-                <p class="font-medium text-gray-900 text-sm truncate" :text="reviewer.name"></p>
-                <p class="text-emerald-700 text-xs" :text="`${reviewer.review_count} ${reviewer.review_count === 1 ? 'review' : 'reviews'}`"></p>
+                <p class="font-medium text-gray-900 text-sm truncate">{{ reviewer.name }}</p>
+                <p class="text-emerald-700 text-xs">{{ `${reviewer.review_count} ${reviewer.review_count === 1 ? 'review' : 'reviews'}` }}</p>
               </div>
             </StxLink>
           </li>

--- a/resources/views/judges/submit.stx
+++ b/resources/views/judges/submit.stx
@@ -168,7 +168,7 @@
         </div>
       </div>
 
-      <p :show="submitError" class="text-red-600 text-sm" x-text="submitError"></p>
+      <p :show="submitError" class="text-red-600 text-sm">{{ submitError }}</p>
 
       <div class="flex gap-x-4 items-center justify-end">
         <StxLink to="/judges" class="font-semibold text-gray-700 text-sm">Cancel</StxLink>

--- a/resources/views/login.stx
+++ b/resources/views/login.stx
@@ -108,9 +108,7 @@
           role="alert"
           aria-live="polite"
           class="px-4 py-3 text-red-800 text-sm bg-red-50 border border-red-200 rounded-md"
-          x-class="submitError() ? '' : 'hidden'"
-          :text="submitError()"
-        ></div>
+          x-class="submitError() ? '' : 'hidden'">{{ submitError() }}</div>
 
         <button
           type="submit"
@@ -118,7 +116,7 @@
           class="inline-flex items-center justify-center px-3 py-1.5 w-full font-semibold text-sm/6 text-white bg-gray-600 hover:bg-gray-500 rounded-md focus-visible:outline focus-visible:outline-2 focus-visible:outline-gray-600 focus-visible:outline-offset-2 disabled:opacity-50 disabled:cursor-not-allowed shadow-sm"
         >
           <svg :if="loading()" class="animate-spin -ml-0.5 mr-2 h-4 w-4" viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3" class="opacity-25"></circle><path d="M4 12a8 8 0 018-8" stroke="currentColor" stroke-width="3" stroke-linecap="round"></path></svg>
-          <span :text="loading() ? 'Signing in...' : 'Sign in'"></span>
+          <span>{{ loading() ? 'Signing in...' : 'Sign in' }}</span>
         </button>
       </form>
     </div>

--- a/resources/views/register.stx
+++ b/resources/views/register.stx
@@ -142,9 +142,7 @@
           role="alert"
           aria-live="polite"
           class="px-4 py-3 text-red-800 text-sm bg-red-50 border border-red-200 rounded-md"
-          x-class="submitError() ? '' : 'hidden'"
-          :text="submitError()"
-        ></div>
+          x-class="submitError() ? '' : 'hidden'">{{ submitError() }}</div>
 
         <button
           type="submit"
@@ -152,7 +150,7 @@
           class="inline-flex items-center justify-center px-3 py-1.5 w-full font-semibold text-sm/6 text-white bg-gray-600 hover:bg-gray-500 rounded-md focus-visible:outline focus-visible:outline-2 focus-visible:outline-gray-600 focus-visible:outline-offset-2 disabled:opacity-50 disabled:cursor-not-allowed shadow-sm"
         >
           <svg :if="loading()" class="animate-spin -ml-0.5 mr-2 h-4 w-4" viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3" class="opacity-25"></circle><path d="M4 12a8 8 0 018-8" stroke="currentColor" stroke-width="3" stroke-linecap="round"></path></svg>
-          <span :text="loading() ? 'Creating account...' : 'Sign up'"></span>
+          <span>{{ loading() ? 'Creating account...' : 'Sign up' }}</span>
         </button>
       </form>
     </div>

--- a/resources/views/reset-password.stx
+++ b/resources/views/reset-password.stx
@@ -141,15 +141,13 @@
             role="alert"
             aria-live="polite"
             class="text-red-600 text-sm"
-            x-class="submitError() ? '' : 'hidden'"
-            :text="submitError()"
-          ></p>
+            x-class="submitError() ? '' : 'hidden'">{{ submitError() }}</p>
 
           <button
             type="submit"
             x-disabled="loading"
             class="inline-flex items-center justify-center px-3 py-1.5 w-full font-semibold text-sm/6 text-white bg-gray-600 hover:bg-gray-500 rounded-md focus-visible:outline focus-visible:outline-2 focus-visible:outline-gray-600 focus-visible:outline-offset-2 disabled:opacity-50 disabled:cursor-not-allowed shadow-sm"
-          ><svg :if="loading()" class="animate-spin -ml-0.5 mr-2 h-4 w-4" viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3" class="opacity-25"></circle><path d="M4 12a8 8 0 018-8" stroke="currentColor" stroke-width="3" stroke-linecap="round"></path></svg><span :text="loading() ? 'Saving...' : 'Reset password'"></span></button>
+          ><svg :if="loading()" class="animate-spin -ml-0.5 mr-2 h-4 w-4" viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3" class="opacity-25"></circle><path d="M4 12a8 8 0 018-8" stroke="currentColor" stroke-width="3" stroke-linecap="round"></path></svg><span>{{ loading() ? 'Saving...' : 'Reset password' }}</span></button>
         </form>
       </div>
 


### PR DESCRIPTION
Resolves #66.

stx 0.2.72 fixes the long-standing bug where `{{ }}` rendered as literal text inside client-reactive `:for`/`:if` subtrees (stacksjs/stx#1748 + multi-root setup hydration). The `:text` workaround this app used everywhere is no longer needed, and `{{ }}` is the cleaner, idiomatic form.

### Changes
- **~345 `:text` bindings → `{{ }}`** across 52 `resources/views` + components. Every site sits on/under a client `:for`/`:if` and reads a signal, derived, or loop var.
- Three submit buttons that paired reactive `:text` with a static fallback child (`Notify me` / `Follow` / `Sign in to admin`) now use `{{ }}` whose else-branch carries that default; `x-cloak` guards the pre-hydration frame (consistent with every other reactive interpolation).

### Not touched
- **6 `x-html` bindings stay** — they render server markdown (`review.content`, judge response bodies); `{{ }}` would escape the HTML.
- No `<option>`/`<textarea>` conversions (the runtime renders `{{ }}` as a `<span>`, invalid in text-only elements).
- No server `@foreach`/`@if` bindings; `x-class`/`:show`/etc. left as-is.

### Verification
Rendered the three hand-edited buttons plus the heavily-converted `ArticleView` and `Admin/ReviewsTable` through `processDirectives` — the framework's own render path: all process cleanly, every `{{ }}` preserved/cloaked for hydration, the `x-html` markdown bindings intact (ArticleView 2, ReviewsTable 1), and **zero invalid `<option><span>`**. Framework-level reactive hydration of `{{ }}` under `:for`/`:if` was independently confirmed in a real browser (headless Chrome via CDP) on stx 0.2.72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)