### PR TITLE
fix: revert {{ }} → :text in 6 @include partials (SSR regression from #67)

### DIFF
--- a/resources/components/Bench/Admin/AdminDashboard.stx
+++ b/resources/components/Bench/Admin/AdminDashboard.stx
@@ -38,12 +38,12 @@
   <div class="gap-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
     <StxLink to="/admin/reviews" class="block p-6 bg-white border border-gray-200 rounded-lg hover:shadow-sm transition-shadow">
       <p class="font-medium text-gray-500 text-sm">Pending reviews</p>
-      <p class="mt-2 font-bold text-3xl text-gray-900">{{ pendingCount() }}</p>
+      <p class="mt-2 font-bold text-3xl text-gray-900" :text="pendingCount()"></p>
       <p class="mt-2 font-semibold text-gray-600 text-sm">Open moderation queue &rarr;</p>
     </StxLink>
     <StxLink to="/admin/users" class="block p-6 bg-white border border-gray-200 rounded-lg hover:shadow-sm transition-shadow">
       <p class="font-medium text-gray-500 text-sm">Total users</p>
-      <p class="mt-2 font-bold text-3xl text-gray-900">{{ userCount() }}</p>
+      <p class="mt-2 font-bold text-3xl text-gray-900" :text="userCount()"></p>
       <p class="mt-2 font-semibold text-gray-600 text-sm">Manage users &rarr;</p>
     </StxLink>
     <div class="block p-6 bg-white border border-gray-200 rounded-lg">

--- a/resources/components/Bench/Admin/AdminShell.stx
+++ b/resources/components/Bench/Admin/AdminShell.stx
@@ -107,7 +107,7 @@
         </nav>
       </div>
       <div class="flex gap-x-4 items-center">
-        <span class="hidden sm:inline text-gray-600 text-sm">{{ adminName }}</span>
+        <span class="hidden sm:inline text-gray-600 text-sm" :text="adminName"></span>
         <StxLink to="/" class="text-gray-500 text-sm hover:text-gray-900">View site</StxLink>
         <button
           type="button"

--- a/resources/components/Bench/Blog/BlogHeader.stx
+++ b/resources/components/Bench/Blog/BlogHeader.stx
@@ -9,7 +9,7 @@
 <header class="relative">
   <div class="mx-auto pb-8 pt-16 px-4 sm:px-6 lg:px-8 max-w-5xl">
     <div class="text-center">
-      <h1 class="font-bold text-4xl text-gray-900 tracking-tight sm:text-5xl">{{ post.title }}</h1>
+      <h1 class="font-bold text-4xl text-gray-900 tracking-tight sm:text-5xl" :text="post.title"></h1>
     </div>
 
     <!-- Author and meta info -->
@@ -19,16 +19,16 @@
         <img class="h-12 w-12 rounded-full" x-src="post.author.imageUrl" x-alt="post.author.name">
         <div class="ml-3">
           <p class="font-medium text-gray-900 text-sm">
-            <a href="#" class="hover:underline">{{ post.author.name }}</a>
+            <a href="#" class="hover:underline" :text="post.author.name"></a>
           </p>
         </div>
       </div>
 
       <!-- Reading time and date -->
       <div class="flex items-center space-x-4 text-gray-500 text-sm">
-        <span>{{ readingTime }}</span>
+        <span :text="readingTime"></span>
         <span aria-hidden="true">&middot;</span>
-        <time :datetime="post.dateTime">{{ post.date }}</time>
+        <time :datetime="post.dateTime" :text="post.date"></time>
       </div>
     </div>
   </div>

--- a/resources/components/Bench/Court/CourtHeader.stx
+++ b/resources/components/Bench/Court/CourtHeader.stx
@@ -80,9 +80,9 @@
     <div class="flex gap-x-6 items-center">
       <img x-src="courtImage" x-alt="courtName" class="object-cover flex-none h-16 w-16 ring-1 ring-gray-900/10 rounded-lg">
       <div>
-        <div class="text-gray-500 text-sm/6">Courthouse <span class="text-gray-700">{{ `#${courtHeaderId}` }}</span></div>
-        <h1 class="mt-1 font-semibold text-base text-gray-900">{{ courtName }}</h1>
-        <p class="mt-0.5 text-gray-500 text-sm">{{ `${courtCity}${courtCity && courtState ? ', ' : ''}${courtState}` }}</p>
+        <div class="text-gray-500 text-sm/6">Courthouse <span class="text-gray-700" :text="`#${courtHeaderId}`"></span></div>
+        <h1 class="mt-1 font-semibold text-base text-gray-900" :text="courtName"></h1>
+        <p class="mt-0.5 text-gray-500 text-sm" :text="`${courtCity}${courtCity && courtState ? ', ' : ''}${courtState}`"></p>
       </div>
     </div>
   </div>

--- a/resources/components/Bench/PricingSection.stx
+++ b/resources/components/Bench/PricingSection.stx
@@ -43,7 +43,7 @@
         <p class="mt-4 text-gray-600 text-sm/6">Are you a clerk? This is for you.</p>
         <p class="flex gap-x-1 items-baseline mt-6">
           <span class="font-semibold text-4xl text-gray-800 tracking-tight">$0</span>
-          <span class="font-semibold text-gray-600 text-sm/6">/<span>{{ pricingPeriod() === 'monthly' ? 'month' : 'year' }}</span></span>
+          <span class="font-semibold text-gray-600 text-sm/6">/<span x-text="pricingPeriod() === 'monthly' ? 'month' : 'year'"></span></span>
         </p>
         <StxLink to="/register" aria-describedby="tier-free"
           class="block mt-6 px-2.5 py-1.5 font-semibold text-center text-gray-600 text-sm/6 ring-1 ring-gray-200 ring-inset rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-gray-600 focus-visible:outline-offset-2 hover:ring-gray-300">Get
@@ -63,8 +63,8 @@
         <h3 id="tier-hobby" class="font-semibold text-gray-600 text-lg/8">Professional</h3>
         <p class="mt-4 text-gray-600 text-sm/6">For anyone curious about judge reviews.</p>
         <p class="flex gap-x-1 items-baseline mt-6">
-          <span class="font-semibold text-4xl text-gray-800 tracking-tight">$<span>{{ pricingPeriod() === 'monthly' ? '10' : '60' }}</span></span>
-          <span class="font-semibold text-gray-600 text-sm/6">/<span>{{ pricingPeriod() === 'monthly' ? 'month' : 'year' }}</span></span>
+          <span class="font-semibold text-4xl text-gray-800 tracking-tight">$<span x-text="pricingPeriod() === 'monthly' ? '10' : '60'"></span></span>
+          <span class="font-semibold text-gray-600 text-sm/6">/<span x-text="pricingPeriod() === 'monthly' ? 'month' : 'year'"></span></span>
         </p>
         <StxLink to="/register" aria-describedby="tier-hobby"
           class="block mt-6 px-2.5 py-1.5 font-semibold text-center text-sm/6 text-white bg-gray-600 hover:bg-gray-500 rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-gray-600 focus-visible:outline-offset-2 shadow-sm">Get

--- a/resources/components/Bench/VerifyEmail.stx
+++ b/resources/components/Bench/VerifyEmail.stx
@@ -97,13 +97,15 @@
     <!-- Error (bad/expired link) -->
     <div x-class="phase() === 'error' ? '' : 'hidden'">
       <h1 class="font-serif font-bold text-2xl text-gray-900">Verification failed</h1>
-      <p class="mt-2 text-gray-600 text-sm">{{ message() }}</p>
+      <p class="mt-2 text-gray-600 text-sm" :text="message()"></p>
       <button
         type="button"
         @click="resend()"
         x-disabled="resending"
-        class="mt-5 inline-flex items-center px-4 py-2 font-semibold text-white text-sm bg-gray-900 hover:bg-gray-800 rounded-md disabled:opacity-50">{{ resending() ? 'Sending…' : 'Resend verification email' }}</button>
-      <p class="mt-3 text-gray-500 text-xs">{{ resendNote() }}</p>
+        class="mt-5 inline-flex items-center px-4 py-2 font-semibold text-white text-sm bg-gray-900 hover:bg-gray-800 rounded-md disabled:opacity-50"
+        :text="resending() ? 'Sending…' : 'Resend verification email'"
+      ></button>
+      <p class="mt-3 text-gray-500 text-xs" :text="resendNote()"></p>
     </div>
 
     <!-- Landing (arrived at /verify-email with no token) -->
@@ -114,8 +116,10 @@
         type="button"
         @click="resend()"
         x-disabled="resending"
-        class="mt-5 inline-flex items-center px-4 py-2 font-semibold text-gray-800 text-sm bg-white border border-gray-300 rounded-md hover:bg-gray-50 disabled:opacity-50">{{ resending() ? 'Sending…' : 'Resend verification email' }}</button>
-      <p class="mt-3 text-gray-500 text-xs">{{ resendNote() }}</p>
+        class="mt-5 inline-flex items-center px-4 py-2 font-semibold text-gray-800 text-sm bg-white border border-gray-300 rounded-md hover:bg-gray-50 disabled:opacity-50"
+        :text="resending() ? 'Sending…' : 'Resend verification email'"
+      ></button>
+      <p class="mt-3 text-gray-500 text-xs" :text="resendNote()"></p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## What

Reverts the `:text` → `{{ }}` conversion in **6 `@include` partials** that #67 broke. Each goes back to its exact pre-migration `:text`/`x-text` form.

| Partial | Bindings |
|---|---|
| `Bench/Admin/AdminDashboard` | `pendingCount()`, `userCount()` |
| `Bench/Admin/AdminShell` | `adminName` |
| `Bench/Blog/BlogHeader` | `post.title`, `post.author.name`, `readingTime`, `post.date` |
| `Bench/Court/CourtHeader` | `courtName`, `#${courtHeaderId}`, city/state |
| `Bench/PricingSection` | `pricingPeriod()` ×3 |
| `Bench/VerifyEmail` | `message()`, `resendNote()`, `resending()` ×… |

## Why

These partials define their reactive data in their **own `<script client>`**. But `includes.ts` strips a partial's `<script>` *before* `processExpressions` runs, so `usesSignalsInScript` can't detect the `state()`/`derived()` and the `{{ }}` are evaluated server-side (vars undefined → **emptied**). Because the `{{ }}` marker is then gone, the re-executed scoped script has nothing to bind — the elements render **permanently empty**. bench-review is SSR (Mode 1), so this is user-visible (blank admin counts, blank verify-email message, blank blog/court headers, blank pricing period).

`:text` is an *attribute* — it survives server-side untouched, and the client binds it after the scoped script re-runs. That's why the original code worked.

Pages converted in #67 are **unaffected** (a top-level page keeps its `<script>`, so the gate stays true and `{{ }}` is preserved).

## Framework root cause

Full analysis + proposed fix: **stacksjs/stx#1758**. Once stx preserves `{{ }}` in partials that had a client `<script>`, these can migrate back — until then `:text`/`x-text` is required in `@include` partials/components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)